### PR TITLE
fix: handle errors when retrieving mounted image and CD-ROM status

### DIFF
--- a/custom_components/nanokvm/__init__.py
+++ b/custom_components/nanokvm/__init__.py
@@ -27,11 +27,12 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from nanokvm.client import (
+    NanoKVMApiError,
+    NanoKVMAuthenticationFailure,
     NanoKVMClient,
     NanoKVMError,
-    NanoKVMAuthenticationFailure,
 )
-from nanokvm.models import GpioType, HidMode, GetMountedImageRsp, GetCdRomRsp
+from nanokvm.models import GetCdRomRsp, GetMountedImageRsp, GpioType
 
 from .const import (
     ATTR_BUTTON_TYPE,
@@ -283,7 +284,7 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
 
                 try:
                     self.mounted_image = await self.client.get_mounted_image()
-                except NanoKVMError as err:
+                except NanoKVMApiError as err:
                     _LOGGER.error(
                         "Failed to get mounted image, retrieving default value.%s", err
                     )
@@ -291,7 +292,7 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
 
                 try:
                     self.cdrom_status = await self.client.get_cdrom_status()
-                except NanoKVMError as err:
+                except NanoKVMApiError as err:
                     _LOGGER.error(
                         "Failed to get CD-ROM status, retrieving default value. %s", err
                     )

--- a/custom_components/nanokvm/__init__.py
+++ b/custom_components/nanokvm/__init__.py
@@ -281,12 +281,21 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
                 self.oled_info = await self.client.get_oled_info()
                 self.wifi_status = await self.client.get_wifi_status()
 
-                if self.hid_mode.mode == HidMode.HID_ONLY:  # Failsafe to the API throwing errors.
-                    self.mounted_image = GetMountedImageRsp(file="")
-                    self.cdrom_status = GetCdRomRsp(cdrom=0)
-                else:
+                try:
                     self.mounted_image = await self.client.get_mounted_image()
+                except NanoKVMError as err:
+                    _LOGGER.error(
+                        "Failed to get mounted image, retrieving default value.%s", err
+                    )
+                    self.mounted_image = GetMountedImageRsp(file="")
+
+                try:
                     self.cdrom_status = await self.client.get_cdrom_status()
+                except NanoKVMError as err:
+                    _LOGGER.error(
+                        "Failed to get CD-ROM status, retrieving default value. %s", err
+                    )
+                    self.cdrom_status = GetCdRomRsp(cdrom=0)
 
                 return {
                     "device_info": self.device_info,


### PR DESCRIPTION
Fix: Handle API errors for mounted image/CD-ROM

Wrap the `get_mounted_image` and `get_cdrom_status` API calls in individual `try...except` blocks.

This prevents the entire data update from failing if these specific API calls raise a `NanoKVMError`. If an error occurs, it is logged, and a default value is used for the corresponding data, making the integration more resilient to device API issues.

This replaces the previous failsafe logic which only applied in `HID_ONLY` mode.

Fixes #17.