### PR TITLE
Change error logs to debug for API failures in NanoKVM coordinator

### DIFF
--- a/custom_components/nanokvm/__init__.py
+++ b/custom_components/nanokvm/__init__.py
@@ -285,7 +285,7 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
                 try:
                     self.mounted_image = await self.client.get_mounted_image()
                 except NanoKVMApiError as err:
-                    _LOGGER.error(
+                    _LOGGER.debug(
                         "Failed to get mounted image, retrieving default value.%s", err
                     )
                     self.mounted_image = GetMountedImageRsp(file="")
@@ -293,7 +293,7 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
                 try:
                     self.cdrom_status = await self.client.get_cdrom_status()
                 except NanoKVMApiError as err:
-                    _LOGGER.error(
+                    _LOGGER.debug(
                         "Failed to get CD-ROM status, retrieving default value. %s", err
                     )
                     self.cdrom_status = GetCdRomRsp(cdrom=0)


### PR DESCRIPTION
Reduce log level from error to debug when failing to retrieve mounted image or CD-ROM status via API. These failures are handled gracefully by setting default values, so debug level avoids unnecessary alarm in logs while preserving visibility for troubleshooting.