### PR TITLE
Add mouse jiggler control and HDMI toggle support + Update to python-nanokvm v0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ project was created by the use of a LLM (Google Gemini) using Cline, as an exper
 - Paste text via HID keyboard simulation
 - Control OLED display settings
 - Monitor and control mounted images
+- **NEW**: Mouse jiggler control with multiple modes
+- **NEW**: HDMI output control for PCI-E versions
 
 ## Installation
 
@@ -58,6 +60,7 @@ project was created by the use of a LLM (Google Gemini) using Cline, as an exper
 - **WiFi Supported**: Shows if WiFi is supported
 - **WiFi Connected**: Shows if WiFi is connected
 - **CD-ROM Mode**: Shows if the mounted image is in CD-ROM mode
+- **Mouse Jiggler**: Shows if the mouse jiggler is currently active
 
 ### Sensors
 
@@ -74,13 +77,21 @@ project was created by the use of a LLM (Google Gemini) using Cline, as an exper
 - **mDNS**: Toggle mDNS on/off
 - **Virtual Network**: Toggle virtual network device on/off
 - **Virtual Disk**: Toggle virtual disk device on/off
+- **HDMI Output**: Toggle HDMI output on/off (PCI-E versions only)
+
+### Select Entities
+
+- **Mouse Jiggler Mode**: Control mouse jiggler with three modes:
+  - **Disable**: Turn off mouse jiggler
+  - **Relative Mode**: Move mouse cursor in relative movements
+  - **Absolute Mode**: Move mouse cursor to absolute positions
 
 ### Buttons
 
 - **Power Button**: Push the power button
 - **Reset Button**: Push the reset button
 - **Reboot System**: Reboot the NanoKVM device
-- **Reset HDMI**: Reset the HDMI connection (PCIe version only)
+- **Reset HDMI**: Reset the HDMI connection (PCI-E versions only)
 - **Reset HID**: Reset the HID subsystem
 - **Update Application**: Update the NanoKVM application
 
@@ -92,6 +103,7 @@ project was created by the use of a LLM (Google Gemini) using Cline, as an exper
 - **nanokvm.reset_hdmi**: Reset the HDMI connection
 - **nanokvm.reset_hid**: Reset the HID subsystem
 - **nanokvm.wake_on_lan**: Send a Wake-on-LAN packet
+- **nanokvm.set_mouse_jiggler**: Set mouse jiggler mode (disable, relative, absolute)
 
 ## Example Automations
 
@@ -124,11 +136,68 @@ automation:
           text: "username\npassword\n"
 ```
 
+### Enable Mouse Jiggler During Work Hours
+
+```yaml
+automation:
+  - alias: "Enable Mouse Jiggler During Work Hours"
+    trigger:
+      - platform: time
+        at: "09:00:00"
+    action:
+      - service: nanokvm.set_mouse_jiggler
+        data:
+          mode: "relative"
+
+  - alias: "Disable Mouse Jiggler After Work"
+    trigger:
+      - platform: time
+        at: "17:00:00"
+    action:
+      - service: nanokvm.set_mouse_jiggler
+        data:
+          mode: "disable"
+```
+
+### Toggle HDMI Output Based on Presence
+
+```yaml
+automation:
+  - alias: "Turn on HDMI when someone is home"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.someone_home
+        to: "on"
+    action:
+      - service: switch.turn_on
+        target:
+          entity_id: switch.nanokvm_hdmi
+
+  - alias: "Turn off HDMI when nobody is home"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.someone_home
+        to: "off"
+        for: "00:30:00"
+    action:
+      - service: switch.turn_off
+        target:
+          entity_id: switch.nanokvm_hdmi
+```
+
 ## Troubleshooting
 
 - If you can't connect to your NanoKVM device, make sure the IP address/hostname is correct and that the device is reachable from your Home Assistant instance.
 - If authentication fails, verify your username and password.
 - If entities are missing, try restarting Home Assistant.
+- HDMI control is only available on PCI-E versions of the NanoKVM and will automatically be hidden for other hardware versions.
+
+## Supported Languages
+
+This integration includes translations for:
+
+- English (en)
+- Portuguese (Brazil) (pt-BR)
 
 ## License
 

--- a/custom_components/nanokvm/binary_sensor.py
+++ b/custom_components/nanokvm/binary_sensor.py
@@ -19,6 +19,7 @@ from .const import (
     DOMAIN,
     ICON_DISK,
     ICON_MDNS,
+    ICON_MOUSE_JIGGLER,
     ICON_NETWORK,
     ICON_OLED,
     ICON_POWER,
@@ -109,6 +110,14 @@ BINARY_SENSORS: tuple[NanoKVMBinarySensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda coordinator: coordinator.cdrom_status.cdrom == 1,
         available_fn=lambda coordinator: coordinator.mounted_image.file != "",
+    ),
+    NanoKVMBinarySensorEntityDescription(
+        key="mouse_jiggler",
+        name="Mouse Jiggler",
+        icon=ICON_MOUSE_JIGGLER,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coordinator: coordinator.mouse_jiggler_state.enabled if coordinator.mouse_jiggler_state else False,
+        available_fn=lambda coordinator: coordinator.mouse_jiggler_state is not None,
     ),
 )
 

--- a/custom_components/nanokvm/const.py
+++ b/custom_components/nanokvm/const.py
@@ -19,12 +19,15 @@ SERVICE_REBOOT = "reboot"
 SERVICE_RESET_HDMI = "reset_hdmi"
 SERVICE_RESET_HID = "reset_hid"
 SERVICE_WAKE_ON_LAN = "wake_on_lan"
+SERVICE_SET_MOUSE_JIGGLER = "set_mouse_jiggler"
 
 # Service attributes
 ATTR_BUTTON_TYPE = "button_type"
 ATTR_DURATION = "duration"
 ATTR_TEXT = "text"
 ATTR_MAC = "mac"
+ATTR_ENABLED = "enabled"
+ATTR_MODE = "mode"
 
 # Button types
 BUTTON_TYPE_POWER = "power"
@@ -47,3 +50,5 @@ ICON_OLED = "mdi:monitor-small"
 ICON_WIFI = "mdi:wifi"
 ICON_IMAGE = "mdi:disc"
 ICON_CDROM = "mdi:disc"
+ICON_MOUSE_JIGGLER = "mdi:mouse"
+ICON_HDMI = "mdi:video-input-hdmi"

--- a/custom_components/nanokvm/manifest.json
+++ b/custom_components/nanokvm/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://github.com/Wouter0100/homeassistant-nanokvm",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Wouter0100/homeassistant-nanokvm/issues",
-  "requirements": ["nanokvm@git+https://github.com/Wouter0100/python-nanokvm.git@patch-1"],
-  "version": "0.0.1",
+  "requirements": ["nanokvm>=0.0.4"],
+  "version": "0.1.0",
   "zeroconf": ["_workstation._tcp.local."]
 }

--- a/custom_components/nanokvm/select.py
+++ b/custom_components/nanokvm/select.py
@@ -1,0 +1,100 @@
+"""Select platform for Sipeed NanoKVM."""
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from nanokvm.models import MouseJigglerMode
+
+from .const import (
+    DOMAIN,
+    ICON_MOUSE_JIGGLER,
+)
+from . import NanoKVMDataUpdateCoordinator, NanoKVMEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class NanoKVMSelectEntityDescription(SelectEntityDescription):
+    """Describes NanoKVM select entity."""
+
+    value_fn: Callable[[NanoKVMDataUpdateCoordinator], str] = None
+    available_fn: Callable[[NanoKVMDataUpdateCoordinator], bool] = lambda _: True
+    select_option_fn: Callable[[NanoKVMDataUpdateCoordinator, str], None] = None
+
+
+SELECTS: tuple[NanoKVMSelectEntityDescription, ...] = (
+    NanoKVMSelectEntityDescription(
+        key="mouse_jiggler_mode",
+        name="Mouse Jiggler Mode",
+        icon=ICON_MOUSE_JIGGLER,
+        entity_category=EntityCategory.CONFIG,
+        options=["Disable", "Relative Mode", "Absolute Mode"],
+        value_fn=lambda coordinator: (
+            "Disable" if not coordinator.mouse_jiggler_state or not coordinator.mouse_jiggler_state.enabled
+            else "Relative Mode" if coordinator.mouse_jiggler_state.mode == MouseJigglerMode.RELATIVE
+            else "Absolute Mode"
+        ),
+        select_option_fn=lambda coordinator, option: coordinator.client.set_mouse_jiggler_state(
+            option != "Disable",
+            MouseJigglerMode.RELATIVE if option == "Relative Mode" else MouseJigglerMode.ABSOLUTE
+        ),
+        available_fn=lambda coordinator: coordinator.mouse_jiggler_state is not None,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up NanoKVM select based on a config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_entities(
+        NanoKVMSelect(
+            coordinator=coordinator,
+            description=description,
+        )
+        for description in SELECTS
+        if description.available_fn(coordinator)
+    )
+
+
+class NanoKVMSelect(NanoKVMEntity, SelectEntity):
+    """Defines a NanoKVM select."""
+
+    entity_description: NanoKVMSelectEntityDescription
+
+    def __init__(
+        self,
+        coordinator: NanoKVMDataUpdateCoordinator,
+        description: NanoKVMSelectEntityDescription,
+    ) -> None:
+        """Initialize NanoKVM select."""
+        super().__init__(
+            coordinator=coordinator,
+            name=f"{description.name}",
+            unique_id_suffix=f"select_{description.key}",
+        )
+        self.entity_description = description
+
+    @property
+    def current_option(self) -> str:
+        """Return the current selected option."""
+        return self.entity_description.value_fn(self.coordinator)
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        await self.entity_description.select_option_fn(self.coordinator, option)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/nanokvm/translations/en.json
+++ b/custom_components/nanokvm/translations/en.json
@@ -58,6 +58,9 @@
       },
       "cdrom_mode": {
         "name": "CD-ROM Mode"
+      },
+      "mouse_jiggler": {
+        "name": "Mouse Jiggler"
       }
     },
     "sensor": {
@@ -89,6 +92,22 @@
       },
       "virtual_disk": {
         "name": "Virtual Disk"
+      },
+      "power": {
+        "name": "Power"
+      },
+      "hdmi": {
+        "name": "HDMI Output"
+      }
+    },
+    "select": {
+      "mouse_jiggler_mode": {
+        "name": "Mouse Jiggler Mode",
+        "state": {
+          "disable": "Disable",
+          "relative_mode": "Relative Mode",
+          "absolute_mode": "Absolute Mode"
+        }
       }
     },
     "button": {
@@ -156,6 +175,20 @@
         "mac": {
           "name": "MAC Address",
           "description": "The MAC address to send the Wake-on-LAN packet to."
+        }
+      }
+    },
+    "set_mouse_jiggler": {
+      "name": "Set Mouse Jiggler",
+      "description": "Configure the mouse jiggler state and mode.",
+      "fields": {
+        "enabled": {
+          "name": "Enabled",
+          "description": "Enable or disable the mouse jiggler."
+        },
+        "mode": {
+          "name": "Mode",
+          "description": "The mouse jiggler mode (absolute or relative)."
         }
       }
     }

--- a/custom_components/nanokvm/translations/pt-BR.json
+++ b/custom_components/nanokvm/translations/pt-BR.json
@@ -58,6 +58,9 @@
       },
       "cdrom_mode": {
         "name": "Modo CD-ROM"
+      },
+      "mouse_jiggler": {
+        "name": "Mouse Jiggler"
       }
     },
     "sensor": {
@@ -89,6 +92,22 @@
       },
       "virtual_disk": {
         "name": "Disco Virtual"
+      },
+      "power": {
+        "name": "Alimentação"
+      },
+      "hdmi": {
+        "name": "Saída HDMI"
+      }
+    },
+    "select": {
+      "mouse_jiggler_mode": {
+        "name": "Modo Mouse Jiggler",
+        "state": {
+          "disable": "Desabilitar",
+          "relative": "Modo Relativo",
+          "absolute": "Modo Absoluto"
+        }
       }
     },
     "button": {
@@ -156,6 +175,16 @@
         "mac": {
           "name": "Endereço MAC",
           "description": "O endereço MAC para o qual enviar o pacote Wake-on-LAN."
+        }
+      }
+    },
+    "set_mouse_jiggler": {
+      "name": "Definir Mouse Jiggler",
+      "description": "Define o modo do mouse jiggler.",
+      "fields": {
+        "mode": {
+          "name": "Modo",
+          "description": "O modo do mouse jiggler (disable, relative, absolute)."
         }
       }
     }

--- a/hacs.json
+++ b/hacs.json
@@ -2,6 +2,6 @@
   "name": "Sipeed NanoKVM",
   "content_in_root": false,
   "render_readme": true,
-  "domains": ["binary_sensor", "button", "sensor", "switch"],
+  "domains": ["binary_sensor", "button", "sensor", "switch", "select"],
   "homeassistant": "2023.8.0"
 }


### PR DESCRIPTION
### 🚀 Features Added

__Mouse Jiggler Control (Fixes #9)__

- Added mouse jiggler binary sensor to monitor current status

- Implemented mouse jiggler select entity with three modes matching NanoKVM web UI:

  - Disable
  - Relative Mode
  - Absolute Mode

- Added `set_mouse_jiggler` service for programmatic control

__HDMI Control for PCI-E Versions (Fixes #3)__

- Added HDMI output toggle switch for PCI-E NanoKVM versions

### 🔧 Technical Improvements

__Library Update__

- Updated dependency from forked version to official `nanokvm>=0.0.4`

This update significantly improves the NanoKVM integration by addressing the most requested features while maintaining backward compatibility and following Home Assistant best practices.
