### PR TITLE
chore: pin nanokvm dependency and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ ENV/
 # OS specific files
 .DS_Store
 Thumbs.db
+
+# Development container files
+.devcontainer.json
+docker-compose.yml

--- a/custom_components/nanokvm/manifest.json
+++ b/custom_components/nanokvm/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://github.com/Wouter0100/homeassistant-nanokvm",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Wouter0100/homeassistant-nanokvm/issues",
-  "requirements": ["nanokvm>=0.2.0"],
+  "requirements": ["nanokvm==0.2.0"],
   "version": "0.1.0",
   "zeroconf": ["_workstation._tcp.local."]
 }


### PR DESCRIPTION
- Pin nanokvm requirement to version 0.2.0 in manifest.json to ensure stability and prevent breaking changes from future updates.
- Update .gitignore to exclude .devcontainer.json and docker-compose.yml, keeping development environment configuration files out of the repository.