### PR TITLE
feat: add SSH-based diagnostic sensors

### DIFF
--- a/custom_components/nanokvm/const.py
+++ b/custom_components/nanokvm/const.py
@@ -52,3 +52,6 @@ ICON_IMAGE = "mdi:disc"
 ICON_CDROM = "mdi:disc"
 ICON_MOUSE_JIGGLER = "mdi:mouse"
 ICON_HDMI = "mdi:video-input-hdmi"
+
+# Signals
+SIGNAL_NEW_SSH_SENSORS = "nanokvm_new_ssh_sensors_{}"

--- a/custom_components/nanokvm/sensor.py
+++ b/custom_components/nanokvm/sensor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+import logging
 from typing import Any
 
 from homeassistant.components.sensor import (
@@ -12,20 +13,25 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfTime
-from homeassistant.core import HomeAssistant
+from homeassistant.const import PERCENTAGE, UnitOfTime
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
     DOMAIN,
+    ICON_DISK,
     ICON_HID,
     ICON_IMAGE,
     ICON_KVM,
     ICON_OLED,
+    ICON_SSH,
+    SIGNAL_NEW_SSH_SENSORS,
 )
 from . import NanoKVMDataUpdateCoordinator, NanoKVMEntity
 
+_LOGGER = logging.getLogger(__name__)
 
 @dataclass
 class NanoKVMSensorEntityDescription(SensorEntityDescription):
@@ -33,6 +39,7 @@ class NanoKVMSensorEntityDescription(SensorEntityDescription):
 
     value_fn: Callable[[NanoKVMDataUpdateCoordinator], Any] = None
     available_fn: Callable[[NanoKVMDataUpdateCoordinator], bool] = lambda _: True
+    attributes_fn: Callable[[NanoKVMDataUpdateCoordinator], dict[str, Any]] = lambda _: {}
 
 
 SENSORS: tuple[NanoKVMSensorEntityDescription, ...] = (
@@ -78,6 +85,48 @@ SENSORS: tuple[NanoKVMSensorEntityDescription, ...] = (
     ),
 )
 
+SSH_SENSORS: tuple[NanoKVMSensorEntityDescription, ...] = (
+    NanoKVMSensorEntityDescription(
+        key="uptime",
+        name="Uptime",
+        icon=ICON_SSH,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.TIMESTAMP,
+        value_fn=lambda coordinator: coordinator.uptime,
+        available_fn=lambda coordinator: coordinator.uptime is not None,
+    ),
+    NanoKVMSensorEntityDescription(
+        key="memory_used_percent",
+        name="Memory Used",
+        icon="mdi:memory",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coordinator: coordinator.memory_used_percent,
+        available_fn=lambda coordinator: coordinator.memory_used_percent is not None,
+        attributes_fn=lambda coordinator: (
+            {"total_mb": coordinator.memory_total}
+            if coordinator.memory_total is not None
+            else {}
+        ),
+    ),
+    NanoKVMSensorEntityDescription(
+        key="storage_used_percent",
+        name="Storage Used",
+        icon=ICON_DISK,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coordinator: coordinator.storage_used_percent,
+        available_fn=lambda coordinator: coordinator.storage_used_percent is not None,
+        attributes_fn=lambda coordinator: (
+            {"total_mb": coordinator.storage_total}
+            if coordinator.storage_total is not None
+            else {}
+        ),
+    ),
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -94,6 +143,37 @@ async def async_setup_entry(
         )
         for description in SENSORS
         if description.available_fn(coordinator)
+    )
+
+    # Add SSH sensors if SSH is already enabled
+    if coordinator.ssh_state and coordinator.ssh_state.enabled:
+        _LOGGER.debug("SSH already enabled, creating SSH sensors")
+        async_add_entities(
+            NanoKVMSensor(
+                coordinator=coordinator,
+                description=description,
+            )
+            for description in SSH_SENSORS
+        )
+        coordinator.ssh_sensors_created = True
+
+    # Listen for signal to add SSH sensors later
+    @callback
+    def async_add_ssh_sensors() -> None:
+        """Add SSH sensors when SSH is enabled."""
+        _LOGGER.debug("Received signal to create SSH sensors")
+        async_add_entities(
+            NanoKVMSensor(
+                coordinator=coordinator,
+                description=description,
+            )
+            for description in SSH_SENSORS
+        )
+
+    entry.async_on_unload(
+        async_dispatcher_connect(
+            hass, SIGNAL_NEW_SSH_SENSORS.format(entry.entry_id), async_add_ssh_sensors
+        )
     )
 
 
@@ -116,6 +196,16 @@ class NanoKVMSensor(NanoKVMEntity, SensorEntity):
         self.entity_description = description
 
     @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self.entity_description.available_fn(self.coordinator)
+
+    @property
     def native_value(self) -> Any:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional state attributes."""
+        return self.entity_description.attributes_fn(self.coordinator)

--- a/custom_components/nanokvm/ssh_metrics.py
+++ b/custom_components/nanokvm/ssh_metrics.py
@@ -1,0 +1,93 @@
+"""SSH metrics collection helpers for NanoKVM."""
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+
+from homeassistant.util import dt as dt_util
+
+from nanokvm.ssh_client import NanoKVMSSH
+
+
+@dataclass(slots=True)
+class SSHMetricsSnapshot:
+    """Snapshot of metrics collected via SSH."""
+
+    uptime: datetime.datetime | None
+    memory_total: float | None
+    memory_used_percent: float | None
+    storage_total: float | None
+    storage_used_percent: float | None
+
+
+class SSHMetricsCollector:
+    """Collect metrics from NanoKVM over SSH."""
+
+    def __init__(self, host: str, password: str, username: str = "root") -> None:
+        """Initialize the SSH collector."""
+        self._password = password
+        self._client = NanoKVMSSH(host=host, username=username)
+
+    async def disconnect(self) -> None:
+        """Disconnect the underlying SSH client if connected."""
+        if self._client.ssh_client:
+            await self._client.disconnect()
+
+    async def collect(self) -> SSHMetricsSnapshot:
+        """Collect uptime, memory and storage stats."""
+        if (
+            not self._client.ssh_client
+            or not self._client.ssh_client.get_transport()
+            or not self._client.ssh_client.get_transport().is_active()
+        ):
+            await self._client.authenticate(self._password)
+
+        uptime = await self._fetch_uptime()
+        memory_stats = await self._fetch_memory()
+        storage_stats = await self._fetch_storage()
+
+        return SSHMetricsSnapshot(
+            uptime=uptime,
+            memory_total=memory_stats.get("total"),
+            memory_used_percent=memory_stats.get("used_percent"),
+            storage_total=storage_stats.get("total"),
+            storage_used_percent=storage_stats.get("used_percent"),
+        )
+
+    async def _fetch_uptime(self) -> datetime.datetime | None:
+        """Fetch uptime via SSH."""
+        uptime_raw = await self._client.run_command("cat /proc/uptime")
+        uptime_seconds = float(uptime_raw.split()[0])
+        return dt_util.utcnow() - datetime.timedelta(seconds=uptime_seconds)
+
+    async def _fetch_memory(self) -> dict[str, float | None]:
+        """Fetch memory stats via SSH."""
+        meminfo = await self._client.run_command("cat /proc/meminfo")
+        mem_data = {}
+        for line in meminfo.splitlines():
+            parts = line.split()
+            if len(parts) >= 2:
+                mem_data[parts[0].rstrip(":")] = int(parts[1])
+
+        stats = {"total": None, "used_percent": None}
+        if "MemTotal" in mem_data:
+            stats["total"] = round(mem_data["MemTotal"] / 1024, 2)
+            if stats["total"] > 0 and "MemFree" in mem_data:
+                memory_free = round(mem_data["MemFree"] / 1024, 2)
+                memory_used = round(stats["total"] - memory_free, 2)
+                stats["used_percent"] = round((memory_used / stats["total"]) * 100, 2)
+        return stats
+
+    async def _fetch_storage(self) -> dict[str, float | None]:
+        """Fetch storage stats via SSH."""
+        df_output = await self._client.run_command("df -k /")
+        lines = df_output.splitlines()
+        stats = {"total": None, "used_percent": None}
+        if len(lines) >= 2:
+            parts = lines[1].split()
+            if len(parts) >= 4:
+                stats["total"] = round(int(parts[1]) / 1024, 2)
+                storage_used = round(int(parts[2]) / 1024, 2)
+                if stats["total"] > 0:
+                    stats["used_percent"] = round((storage_used / stats["total"]) * 100, 2)
+        return stats


### PR DESCRIPTION
## Summary
This PR adds new SSH-based monitoring features for NanoKVM in Home Assistant.

## New Features
- New system health sensors (via SSH):
  - Uptime
  - Memory usage (with total memory as an attribute)
  - Storage usage (with total storage as an attribute)

## Important
- The new system health sensors require SSH to be enabled on the NanoKVM device.
- If SSH is disabled, these sensors will not report data.

## Why this is useful
- Gives better visibility into NanoKVM health and resource usage.
- Keeps the UI cleaner by exposing mostly fixed totals as attributes instead of separate entities.
- Creates a clear path to add more sensors in the future, since SSH access allows using standard Linux commands to collect additional metrics.