### PR TITLE
feat(camera): replace MJPEG live stream with native WebRTC signaling

### DIFF
--- a/custom_components/nanokvm/camera.py
+++ b/custom_components/nanokvm/camera.py
@@ -1,24 +1,33 @@
 """Camera platform for Sipeed NanoKVM."""
 from __future__ import annotations
 
-import io
+import asyncio
 import logging
-import secrets
-from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from homeassistant.components.camera import Camera
+import aiohttp
+from aiohttp import BodyPartReader, MultipartReader
+from homeassistant.components.camera import Camera, CameraEntityFeature
+from homeassistant.components.camera.webrtc import WebRTCSendMessage
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from nanokvm.utils import obfuscate_password
+from webrtc_models import RTCIceCandidateInit
 
+from . import NanoKVMDataUpdateCoordinator, NanoKVMEntity
+from .camera_webrtc import NanoKVMWebRTCManager
 from .config_flow import normalize_host
 from .const import DOMAIN, ICON_HDMI
-from . import NanoKVMDataUpdateCoordinator, NanoKVMEntity
 
 _LOGGER = logging.getLogger(__name__)
+
+LOGIN_TIMEOUT_SECONDS = 15
+WEBSOCKET_HEARTBEAT_SECONDS = 30.0
+MAX_PENDING_ICE_CANDIDATES = 64
+SNAPSHOT_TIMEOUT_SECONDS = 20
 
 
 @dataclass(kw_only=True)
@@ -72,40 +81,124 @@ class NanoKVMCamera(NanoKVMEntity, Camera):
             coordinator=coordinator,
             unique_id_suffix=f"camera_{description.key}",
         )
-        self.access_tokens: deque[str] = deque()
-        self._webrtc_provider = None
-        self._rtsp_provider = None
-        self._stream_provider = None
-        self._supports_native_async_webrtc = False
-        self._supports_native_webrtc = False
-        self._supports_native_async_rtsp = False
-        self._supports_native_rtsp = False
-        self.content_type = "image/jpeg"
+        Camera.__init__(self)
+        self._attr_supported_features = CameraEntityFeature.STREAM
+        self._attr_is_streaming = True
+        self._webrtc = NanoKVMWebRTCManager(
+            logger=_LOGGER,
+            hass_provider=lambda: self.hass,
+            connection_info_provider=self._stream_connection_info,
+            authenticate_stream=self._authenticate_stream,
+            login_timeout_seconds=LOGIN_TIMEOUT_SECONDS,
+            websocket_heartbeat_seconds=WEBSOCKET_HEARTBEAT_SECONDS,
+            max_pending_ice_candidates=MAX_PENDING_ICE_CANDIDATES,
+        )
 
-        self.access_tokens.append(self.generate_access_token())
-
-    async def stream_source(self) -> str | None:
-        """Return the MJPEG stream URL."""
+    def _stream_connection_info(self) -> tuple[str, str, str] | None:
+        """Return normalized base URL and credentials for stream auth/signaling."""
         config_entry = self.coordinator.config_entry
-        if config_entry and config_entry.data:
-            host = normalize_host(config_entry.data.get("host", ""))
-            return f"{host.rstrip('/')}/stream/mjpeg"
-        return None
+        if not config_entry or not config_entry.data:
+            return None
+
+        host = config_entry.data.get("host")
+        username = config_entry.data.get("username")
+        password = config_entry.data.get("password")
+
+        if not host or not username or not password:
+            return None
+
+        return normalize_host(host), username, password
+
+    async def _authenticate_stream(
+        self,
+        session: aiohttp.ClientSession,
+        base_url: str,
+        username: str,
+        password: str,
+    ) -> str:
+        """Authenticate directly against NanoKVM API and return JWT token."""
+        async with session.post(
+            f"{base_url}auth/login",
+            json={
+                "username": username,
+                "password": obfuscate_password(password),
+            },
+            timeout=aiohttp.ClientTimeout(total=LOGIN_TIMEOUT_SECONDS),
+            raise_for_status=True,
+        ) as response:
+            payload = await response.json(content_type=None)
+
+        code = payload.get("code") if isinstance(payload, dict) else None
+        token = payload.get("data", {}).get("token") if isinstance(payload, dict) else None
+        if code != 0 or not token:
+            msg = payload.get("msg", "unknown") if isinstance(payload, dict) else "unknown"
+            raise RuntimeError(f"Stream authentication failed: code={code}, msg={msg}")
+        return token
+
+    async def _async_read_snapshot_frame(self) -> bytes | None:
+        """Read one JPEG frame from NanoKVM MJPEG endpoint for snapshots."""
+        conn = self._stream_connection_info()
+        if conn is None:
+            return None
+
+        base_url, username, password = conn
+        stream_url = f"{base_url}stream/mjpeg"
+
+        async with aiohttp.ClientSession() as session:
+            token = await self._authenticate_stream(session, base_url, username, password)
+            async with session.get(
+                stream_url,
+                cookies={"nano-kvm-token": token},
+                timeout=aiohttp.ClientTimeout(total=None, sock_read=None),
+                raise_for_status=True,
+            ) as upstream:
+                reader = MultipartReader.from_response(upstream)
+
+                while True:
+                    async with asyncio.timeout(SNAPSHOT_TIMEOUT_SECONDS):
+                        part = await reader.next()
+
+                    if part is None:
+                        return None
+                    if not isinstance(part, BodyPartReader):
+                        continue
+
+                    async with asyncio.timeout(SNAPSHOT_TIMEOUT_SECONDS):
+                        payload = await part.read()
+
+                    if payload:
+                        return payload
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
         """Return a still image response from the camera."""
         try:
-            async with self.coordinator.client:
-                async for image in self.coordinator.client.mjpeg_stream():
-                    img_byte_arr = io.BytesIO()
-                    image.save(img_byte_arr, format='JPEG')
-                    return img_byte_arr.getvalue()
+            return await self._async_read_snapshot_frame()
         except Exception as err:
             _LOGGER.error("Error fetching still image: %s", err)
             return None
 
-    def generate_access_token(self) -> str:
-        """Generate a random access token for camera security."""
-        return secrets.token_hex(32)
+    async def async_handle_async_webrtc_offer(
+        self, offer_sdp: str, session_id: str, send_message: WebRTCSendMessage
+    ) -> None:
+        """Handle Home Assistant WebRTC offer using NanoKVM signaling."""
+        await self._webrtc.async_handle_async_webrtc_offer(
+            offer_sdp, session_id, send_message
+        )
+
+    async def async_on_webrtc_candidate(
+        self, session_id: str, candidate: RTCIceCandidateInit
+    ) -> None:
+        """Forward frontend ICE candidates to NanoKVM signaling websocket."""
+        await self._webrtc.async_on_webrtc_candidate(session_id, candidate)
+
+    @callback
+    def close_webrtc_session(self, session_id: str) -> None:
+        """Close a WebRTC session when frontend unsubscribes."""
+        self._webrtc.close_webrtc_session(session_id)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Cleanup camera resources when entity is removed."""
+        await super().async_will_remove_from_hass()
+        await self._webrtc.async_shutdown()

--- a/custom_components/nanokvm/camera_webrtc.py
+++ b/custom_components/nanokvm/camera_webrtc.py
@@ -1,0 +1,299 @@
+"""WebRTC signaling helpers for the NanoKVM camera entity."""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from contextlib import suppress
+from dataclasses import dataclass
+
+import aiohttp
+from aiohttp import WSMsgType
+from homeassistant.components.camera.webrtc import (
+    WebRTCAnswer,
+    WebRTCCandidate,
+    WebRTCError,
+    WebRTCSendMessage,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from webrtc_models import RTCIceCandidateInit
+from yarl import URL
+
+@dataclass(slots=True)
+class _NanoKVMWebRTCSession:
+    """Internal state for an active NanoKVM WebRTC signaling session."""
+
+    http_session: aiohttp.ClientSession
+    websocket: aiohttp.ClientWebSocketResponse
+    reader_task: asyncio.Task[None] | None = None
+
+
+class NanoKVMWebRTCManager:
+    """Manage native Home Assistant WebRTC signaling for NanoKVM cameras."""
+
+    def __init__(
+        self,
+        *,
+        logger: logging.Logger,
+        hass_provider: Callable[[], HomeAssistant | None],
+        connection_info_provider: Callable[[], tuple[str, str, str] | None],
+        authenticate_stream: Callable[
+            [aiohttp.ClientSession, str, str, str], Awaitable[str]
+        ],
+        login_timeout_seconds: int = 15,
+        websocket_heartbeat_seconds: float = 30.0,
+        max_pending_ice_candidates: int = 64,
+    ) -> None:
+        """Initialize WebRTC manager."""
+        self._logger = logger
+        self._hass_provider = hass_provider
+        self._connection_info_provider = connection_info_provider
+        self._authenticate_stream = authenticate_stream
+        self._login_timeout_seconds = login_timeout_seconds
+        self._websocket_heartbeat_seconds = websocket_heartbeat_seconds
+        self._max_pending_ice_candidates = max_pending_ice_candidates
+        self._sessions: dict[str, _NanoKVMWebRTCSession] = {}
+        self._pending_candidates: dict[str, list[RTCIceCandidateInit]] = {}
+        self._session_lock = asyncio.Lock()
+
+    def _webrtc_stream_url(self, base_url: str) -> str:
+        """Build NanoKVM h264 WebRTC websocket URL from API base URL."""
+        api_url = URL(base_url)
+        ws_scheme = "wss" if api_url.scheme == "https" else "ws"
+        return str(api_url.with_scheme(ws_scheme) / "stream/h264")
+
+    def _websocket_timeout(self) -> aiohttp.ClientWSTimeout | float:
+        """Return websocket timeout object compatible with installed aiohttp."""
+        ws_timeout_cls = getattr(aiohttp, "ClientWSTimeout", None)
+        if ws_timeout_cls is None:
+            return self._login_timeout_seconds
+        return ws_timeout_cls(ws_close=self._login_timeout_seconds)
+
+    async def async_handle_async_webrtc_offer(
+        self, offer_sdp: str, session_id: str, send_message: WebRTCSendMessage
+    ) -> None:
+        """Handle Home Assistant WebRTC offer using NanoKVM /stream/h264 signaling."""
+        conn = self._connection_info_provider()
+        if conn is None:
+            raise HomeAssistantError("Missing NanoKVM connection info")
+
+        hass = self._hass_provider()
+        if hass is None:
+            raise HomeAssistantError("Home Assistant is not ready for WebRTC")
+
+        base_url, username, password = conn
+        ws_url = self._webrtc_stream_url(base_url)
+
+        http_session = aiohttp.ClientSession()
+        registered = False
+
+        # Frontend can send ICE candidates before signaling websocket is ready.
+        async with self._session_lock:
+            self._pending_candidates.setdefault(session_id, [])
+
+        try:
+            token = await self._authenticate_stream(
+                http_session, base_url, username, password
+            )
+            websocket = await http_session.ws_connect(
+                ws_url,
+                headers={"Cookie": f"nano-kvm-token={token}"},
+                heartbeat=self._websocket_heartbeat_seconds,
+                timeout=self._websocket_timeout(),
+            )
+
+            webrtc_session = _NanoKVMWebRTCSession(
+                http_session=http_session,
+                websocket=websocket,
+            )
+            async with self._session_lock:
+                self._sessions[session_id] = webrtc_session
+                registered = True
+
+            webrtc_session.reader_task = hass.async_create_task(
+                self._async_webrtc_reader(session_id, send_message)
+            )
+
+            offer_data = json.dumps({"type": "offer", "sdp": offer_sdp})
+            await websocket.send_json({"event": "video-offer", "data": offer_data})
+            await self._async_flush_pending_candidates(session_id, websocket)
+        except Exception as err:
+            if registered:
+                await self._async_close_webrtc_session(session_id)
+            else:
+                async with self._session_lock:
+                    self._pending_candidates.pop(session_id, None)
+                with suppress(Exception):
+                    await http_session.close()
+            raise HomeAssistantError(
+                f"Unable to establish NanoKVM WebRTC signaling: {err}"
+            ) from err
+
+    async def _async_webrtc_reader(
+        self, session_id: str, send_message: WebRTCSendMessage
+    ) -> None:
+        """Read NanoKVM signaling messages and forward them to HA frontend."""
+        async with self._session_lock:
+            session = self._sessions.get(session_id)
+
+        if session is None:
+            return
+
+        ws = session.websocket
+
+        try:
+            async for msg in ws:
+                if msg.type != WSMsgType.TEXT:
+                    if msg.type in (WSMsgType.CLOSED, WSMsgType.CLOSE, WSMsgType.ERROR):
+                        break
+                    continue
+
+                try:
+                    payload = json.loads(msg.data)
+                except (TypeError, json.JSONDecodeError):
+                    self._logger.debug(
+                        "Invalid WebRTC signal message from NanoKVM: %r", msg.data
+                    )
+                    continue
+
+                if not isinstance(payload, dict):
+                    continue
+
+                event = payload.get("event")
+                data_raw = payload.get("data")
+
+                if event == "heartbeat":
+                    continue
+                if not isinstance(data_raw, str):
+                    continue
+
+                try:
+                    data = json.loads(data_raw)
+                except json.JSONDecodeError:
+                    self._logger.debug("Invalid WebRTC signal payload: %r", data_raw)
+                    continue
+
+                if event == "video-answer":
+                    sdp = data.get("sdp") if isinstance(data, dict) else None
+                    if isinstance(sdp, str) and sdp:
+                        send_message(WebRTCAnswer(answer=sdp))
+                elif event == "video-candidate":
+                    if isinstance(data, dict):
+                        try:
+                            candidate = RTCIceCandidateInit.from_dict(data)
+                        except Exception as err:
+                            self._logger.debug(
+                                "Invalid video-candidate payload from NanoKVM: %s (%r)",
+                                err,
+                                data,
+                            )
+                            continue
+                        send_message(WebRTCCandidate(candidate=candidate))
+                else:
+                    self._logger.debug("Unhandled NanoKVM WebRTC event: %s", event)
+        except Exception as err:
+            self._logger.error("Error reading NanoKVM WebRTC signaling: %s", err)
+            send_message(
+                WebRTCError(
+                    code="webrtc_signal_failed",
+                    message=str(err),
+                )
+            )
+        finally:
+            self._logger.debug(
+                "NanoKVM WebRTC signaling ended: session_id=%s close_code=%s exception=%r",
+                session_id,
+                ws.close_code,
+                ws.exception(),
+            )
+            await self._async_close_webrtc_session(session_id)
+
+    async def async_on_webrtc_candidate(
+        self, session_id: str, candidate: RTCIceCandidateInit
+    ) -> None:
+        """Forward frontend ICE candidates to NanoKVM signaling websocket."""
+        async with self._session_lock:
+            session = self._sessions.get(session_id)
+            if session is None or session.websocket.closed:
+                queue = self._pending_candidates.setdefault(session_id, [])
+                if len(queue) < self._max_pending_ice_candidates:
+                    queue.append(candidate)
+                return
+
+        try:
+            await self._async_send_candidate(session.websocket, candidate)
+        except Exception as err:
+            raise HomeAssistantError(
+                f"Unable to forward WebRTC candidate to NanoKVM: {err}"
+            ) from err
+
+    async def _async_send_candidate(
+        self,
+        websocket: aiohttp.ClientWebSocketResponse,
+        candidate: RTCIceCandidateInit,
+    ) -> None:
+        """Send a single ICE candidate to NanoKVM signaling websocket."""
+        payload: dict[str, object] = {
+            "candidate": candidate.candidate,
+        }
+        if candidate.sdp_mid is not None:
+            payload["sdpMid"] = candidate.sdp_mid
+        if candidate.sdp_m_line_index is not None:
+            payload["sdpMLineIndex"] = candidate.sdp_m_line_index
+        if candidate.user_fragment is not None:
+            # NanoKVM (Go/Pion) expects this exact key.
+            payload["usernameFragment"] = candidate.user_fragment
+
+        await websocket.send_json(
+            {
+                "event": "video-candidate",
+                "data": json.dumps(payload),
+            }
+        )
+
+    async def _async_flush_pending_candidates(
+        self, session_id: str, websocket: aiohttp.ClientWebSocketResponse
+    ) -> None:
+        """Flush candidates queued before websocket session became active."""
+        async with self._session_lock:
+            pending = self._pending_candidates.pop(session_id, [])
+
+        for candidate in pending:
+            await self._async_send_candidate(websocket, candidate)
+
+    async def _async_close_webrtc_session(self, session_id: str) -> None:
+        """Close and cleanup an active NanoKVM WebRTC signaling session."""
+        async with self._session_lock:
+            session = self._sessions.pop(session_id, None)
+            self._pending_candidates.pop(session_id, None)
+
+        if session is None:
+            return
+
+        current_task = asyncio.current_task()
+
+        if session.reader_task is not None and session.reader_task is not current_task:
+            session.reader_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await session.reader_task
+
+        with suppress(Exception):
+            if not session.websocket.closed:
+                await session.websocket.close()
+
+        with suppress(Exception):
+            await session.http_session.close()
+
+    def close_webrtc_session(self, session_id: str) -> None:
+        """Close a WebRTC session when frontend unsubscribes."""
+        hass = self._hass_provider()
+        if hass is None:
+            return
+        hass.async_create_task(self._async_close_webrtc_session(session_id))
+
+    async def async_shutdown(self) -> None:
+        """Close all active WebRTC sessions."""
+        for session_id in list(self._sessions):
+            await self._async_close_webrtc_session(session_id)

--- a/custom_components/nanokvm/manifest.json
+++ b/custom_components/nanokvm/manifest.json
@@ -9,5 +9,6 @@
   "issue_tracker": "https://github.com/Wouter0100/homeassistant-nanokvm/issues",
   "requirements": ["nanokvm==0.2.0"],
   "version": "0.1.0",
+  "homeassistant": "2024.12.0",
   "zeroconf": ["_workstation._tcp.local."]
 }

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "content_in_root": false,
   "render_readme": true,
   "domains": ["binary_sensor", "button", "sensor", "switch", "select"],
-  "homeassistant": "2023.8.0"
+  "homeassistant": "2024.12.0"
 }


### PR DESCRIPTION
## Summary
This PR replaces the NanoKVM camera live stream implementation from MJPEG (`stream_source`) to native Home Assistant WebRTC signaling.

## What changed
- Added native WebRTC signaling manager in `custom_components/nanokvm/camera_webrtc.py`.
- Refactored `custom_components/nanokvm/camera.py` to:
  - remove MJPEG live streaming as the primary camera stream path
  - handle WebRTC offers/candidates and session lifecycle
  - keep MJPEG only for still snapshots (`async_camera_image`)
- Updated minimum Home Assistant version to `2024.12.0` in:
  - `custom_components/nanokvm/manifest.json`
  - `hacs.json`

## Why
WebRTC provides a better native camera streaming path in HA and cleaner signaling/session handling than the previous MJPEG stream approach for live view.
