### PR TITLE
feat: add SSH CPU temperature sensor and improve SSH memory/storage metrics

### DIFF
--- a/custom_components/nanokvm/__init__.py
+++ b/custom_components/nanokvm/__init__.py
@@ -287,6 +287,7 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         self.swap_size = None
         self.tailscale_status = None
         self.uptime = None
+        self.cpu_temperature = None
         self.memory_total = None
         self.memory_used_percent = None
         self.storage_total = None
@@ -415,10 +416,18 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             metrics = await self.ssh_metrics_collector.collect()
             self.uptime = metrics.uptime
+            self.cpu_temperature = metrics.cpu_temperature
             self.memory_total = metrics.memory_total
             self.memory_used_percent = metrics.memory_used_percent
             self.storage_total = metrics.storage_total
             self.storage_used_percent = metrics.storage_used_percent
+            _LOGGER.debug(
+                "SSH coordinator metrics updated: uptime=%s cpu_temperature=%s memory_used_percent=%s storage_used_percent=%s",
+                self.uptime,
+                self.cpu_temperature,
+                self.memory_used_percent,
+                self.storage_used_percent,
+            )
 
             if not self.ssh_sensors_created:
                 _LOGGER.debug("SSH enabled, signaling to create SSH sensors")
@@ -428,12 +437,14 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         except Exception as err:
             _LOGGER.debug("Failed to fetch data via SSH: %s", err)
             self.uptime = None
+            self.cpu_temperature = None
             if self.ssh_metrics_collector:
                 await self.ssh_metrics_collector.disconnect()
 
     async def _async_clear_ssh_data(self) -> None:
         """Clear SSH data and disconnect client."""
         self.uptime = None
+        self.cpu_temperature = None
         self.memory_total = None
         self.memory_used_percent = None
         self.storage_total = None

--- a/custom_components/nanokvm/sensor.py
+++ b/custom_components/nanokvm/sensor.py
@@ -13,7 +13,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import EntityCategory
@@ -96,6 +96,18 @@ SSH_SENSORS: tuple[NanoKVMSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=lambda coordinator: coordinator.uptime,
         available_fn=lambda coordinator: coordinator.uptime is not None,
+    ),
+    NanoKVMSensorEntityDescription(
+        key="cpu_temperature",
+        name="CPU Temperature",
+        translation_key="cpu_temperature",
+        icon="mdi:thermometer",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coordinator: coordinator.cpu_temperature,
+        available_fn=lambda coordinator: coordinator.cpu_temperature is not None,
     ),
     NanoKVMSensorEntityDescription(
         key="memory_used_percent",

--- a/custom_components/nanokvm/translations/en.json
+++ b/custom_components/nanokvm/translations/en.json
@@ -123,6 +123,9 @@
       "uptime": {
         "name": "Uptime"
       },
+      "cpu_temperature": {
+        "name": "CPU Temperature"
+      },
       "memory_used_percent": {
         "name": "Memory Used",
         "state_attributes": {

--- a/custom_components/nanokvm/translations/fr.json
+++ b/custom_components/nanokvm/translations/fr.json
@@ -123,6 +123,9 @@
       "uptime": {
         "name": "Temps de fonctionnement"
       },
+      "cpu_temperature": {
+        "name": "Température CPU"
+      },
       "memory_used_percent": {
         "name": "Mémoire utilisée",
         "state_attributes": {

--- a/custom_components/nanokvm/translations/pt-BR.json
+++ b/custom_components/nanokvm/translations/pt-BR.json
@@ -123,6 +123,9 @@
       "uptime": {
         "name": "Tempo de Atividade"
       },
+      "cpu_temperature": {
+        "name": "Temperatura da CPU"
+      },
       "memory_used_percent": {
         "name": "Uso de Memória",
         "state_attributes": {


### PR DESCRIPTION
## Summary

This PR improves SSH-based diagnostics for the NanoKVM integration by adding CPU temperature support and refining existing memory/storage metrics.

## What Changed

- Added SSH CPU temperature metric collection from:
  - `/sys/class/thermal/thermal_zone0/temp`
- Added a new diagnostic sensor:
  - `sensor.cpu_temperature`
- Improved memory usage calculation:
  - uses `MemAvailable` from `/proc/meminfo`
- Improved storage usage calculation:
  - uses `%` directly from `df -k /` (`Use%` column)

## Why

- `MemAvailable` gives a more realistic Linux memory usage value than `MemFree`.
- `df` already provides canonical usage percentage, avoiding unnecessary recalculation.
- Exposing SoC thermal value gives useful hardware diagnostics in Home Assistant.

## Notes

- Temperature source is SoC thermal zone (`thermal_zone0`), reported as the CPU temperature sensor in HA.
