### PR TITLE
docs: refresh AGENTS/README and add complete service examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Notes:
 - Unique ID is based on NanoKVM `device_key`.
 - HTTPS is currently not supported by this integration.
   Use `http://` (or plain IP/hostname).
+- Coordinator polling interval is 30 seconds.
+
+## Known Limitations
+
+- HTTPS/TLS is not supported yet.
+- Host updates from discovery are disabled when **Use static host only** is enabled.
+- Camera stream availability depends on HDMI input/source status.
 
 ## Entities
 
@@ -76,19 +83,32 @@ Notes:
 - HDD LED is Alpha-only.
 - SSH diagnostics require SSH enabled on NanoKVM.
 
+## Hardware Compatibility
+
+| Feature | Availability |
+| --- | --- |
+| HDMI switch/button controls | PCI-E models |
+| HDD LED binary sensor | Alpha models |
+| SSH diagnostic sensors | Any model with SSH enabled |
+
 ## Services
 
 All services are under the `nanokvm` domain.
+For full call examples, see [`SERVICES.md`](SERVICES.md).
 
 | Service | Parameters | Description |
 | --- | --- | --- |
 | `push_button` | `button_type`, `duration` | Simulate a button press |
-| `paste_text` | `text` | Paste ASCII text via HID keyboard |
+| `paste_text` | `text` | Paste text via HID keyboard (ASCII printable only) |
 | `reboot` | - | Reboot NanoKVM |
 | `reset_hdmi` | - | Reset HDMI subsystem |
 | `reset_hid` | - | Reset HID subsystem |
 | `wake_on_lan` | `mac` | Send Wake-on-LAN packet |
 | `set_mouse_jiggler` | `enabled`, `mode` | Set mouse jiggler state |
+
+Notes:
+
+- `push_button.duration` range is `100-5000` ms.
 
 ## Example Automation
 
@@ -125,6 +145,9 @@ automation:
 
 - Documentation: <https://github.com/Wouter0100/homeassistant-nanokvm>
 - Issues: <https://github.com/Wouter0100/homeassistant-nanokvm/issues>
+- Service examples: [`SERVICES.md`](SERVICES.md)
+- Contributing guide: [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- Agent/dev notes: [`AGENTS.md`](AGENTS.md)
 - Python library (`python-nanokvm`):
   <https://github.com/puddly/python-nanokvm>
 - License: MIT (`LICENSE`)

--- a/SERVICES.md
+++ b/SERVICES.md
@@ -1,0 +1,116 @@
+# NanoKVM Service Examples
+
+All service calls use the `nanokvm` domain.
+
+## `nanokvm.push_button`
+
+Simulate pressing the physical power or reset button.
+
+Parameters:
+
+- `button_type`: `power` or `reset` (required)
+- `duration`: `100-5000` milliseconds (optional, default `100`)
+
+Example:
+
+```yaml
+service: nanokvm.push_button
+data:
+  button_type: power
+  duration: 200
+```
+
+## `nanokvm.paste_text`
+
+Paste text through HID keyboard emulation.
+
+Parameters:
+
+- `text`: ASCII printable text (required)
+
+Example:
+
+```yaml
+service: nanokvm.paste_text
+data:
+  text: "sudo reboot"
+```
+
+## `nanokvm.reboot`
+
+Reboot the NanoKVM device itself.
+
+Parameters:
+
+- none
+
+Example:
+
+```yaml
+service: nanokvm.reboot
+data: {}
+```
+
+## `nanokvm.reset_hdmi`
+
+Reset the HDMI subsystem (primarily relevant for PCIe hardware).
+
+Parameters:
+
+- none
+
+Example:
+
+```yaml
+service: nanokvm.reset_hdmi
+data: {}
+```
+
+## `nanokvm.reset_hid`
+
+Reset the HID subsystem.
+
+Parameters:
+
+- none
+
+Example:
+
+```yaml
+service: nanokvm.reset_hid
+data: {}
+```
+
+## `nanokvm.wake_on_lan`
+
+Send a Wake-on-LAN packet to a target MAC address.
+
+Parameters:
+
+- `mac`: target MAC address (required)
+
+Example:
+
+```yaml
+service: nanokvm.wake_on_lan
+data:
+  mac: "00:11:22:33:44:55"
+```
+
+## `nanokvm.set_mouse_jiggler`
+
+Enable/disable mouse jiggler and choose mode.
+
+Parameters:
+
+- `enabled`: `true` or `false` (required)
+- `mode`: `absolute` or `relative` (optional, default `absolute`)
+
+Example:
+
+```yaml
+service: nanokvm.set_mouse_jiggler
+data:
+  enabled: true
+  mode: absolute
+```

--- a/custom_components/nanokvm/services.yaml
+++ b/custom_components/nanokvm/services.yaml
@@ -56,3 +56,23 @@ wake_on_lan:
       example: "00:11:22:33:44:55"
       selector:
         text:
+
+set_mouse_jiggler:
+  name: Set Mouse Jiggler
+  description: Configure the mouse jiggler state and mode.
+  fields:
+    enabled:
+      name: Enabled
+      description: Enable or disable the mouse jiggler.
+      required: true
+      selector:
+        boolean:
+    mode:
+      name: Mode
+      description: The mouse jiggler mode (absolute or relative).
+      default: "absolute"
+      selector:
+        select:
+          options:
+            - "absolute"
+            - "relative"


### PR DESCRIPTION
## Summary

Improves project documentation for contributors and users, and aligns service docs with implemented behavior.

## Changes

- Refresh `AGENTS.md` to reflect current split architecture:
  - `coordinator.py`, `entity.py`, `services.py`, `utils.py`, `ssh_metrics.py`, `camera_webrtc.py`
- Improve `README.md` with:
  - known limitations
  - hardware compatibility notes
  - clearer service constraints
  - links to contributor/agent docs and service examples
- Add `SERVICES.md` with examples for all integration services
- Add missing `set_mouse_jiggler` definition to `custom_components/nanokvm/services.yaml`
