### PR TITLE
fix: scope nanokvm services to a single configured device

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,17 +98,18 @@ For full call examples, see [`SERVICES.md`](SERVICES.md).
 
 | Service | Parameters | Description |
 | --- | --- | --- |
-| `push_button` | `button_type`, `duration` | Simulate a button press |
-| `paste_text` | `text` | Paste text via HID keyboard (ASCII printable only) |
-| `reboot` | - | Reboot NanoKVM |
-| `reset_hdmi` | - | Reset HDMI subsystem |
-| `reset_hid` | - | Reset HID subsystem |
-| `wake_on_lan` | `mac` | Send Wake-on-LAN packet |
-| `set_mouse_jiggler` | `enabled`, `mode` | Set mouse jiggler state |
+| `push_button` | `host`, `button_type`, `duration` | Simulate a button press |
+| `paste_text` | `host`, `text` | Paste text via HID keyboard (ASCII printable only) |
+| `reboot` | `host` | Reboot NanoKVM |
+| `reset_hdmi` | `host` | Reset HDMI subsystem |
+| `reset_hid` | `host` | Reset HID subsystem |
+| `wake_on_lan` | `host`, `mac` | Send Wake-on-LAN packet |
+| `set_mouse_jiggler` | `host`, `enabled`, `mode` | Set mouse jiggler state |
 
 Notes:
 
 - `push_button.duration` range is `100-5000` ms.
+- `host` is optional when one NanoKVM is configured and required when multiple devices are configured.
 
 ## Example Automation
 

--- a/SERVICES.md
+++ b/SERVICES.md
@@ -8,6 +8,7 @@ Simulate pressing the physical power or reset button.
 
 Parameters:
 
+- `host`: optional target host; required when multiple NanoKVM devices are configured
 - `button_type`: `power` or `reset` (required)
 - `duration`: `100-5000` milliseconds (optional, default `100`)
 
@@ -16,6 +17,7 @@ Example:
 ```yaml
 service: nanokvm.push_button
 data:
+  host: "192.168.1.50"
   button_type: power
   duration: 200
 ```
@@ -26,6 +28,7 @@ Paste text through HID keyboard emulation.
 
 Parameters:
 
+- `host`: optional target host; required when multiple NanoKVM devices are configured
 - `text`: ASCII printable text (required)
 
 Example:
@@ -33,6 +36,7 @@ Example:
 ```yaml
 service: nanokvm.paste_text
 data:
+  host: "192.168.1.50"
   text: "sudo reboot"
 ```
 
@@ -42,13 +46,14 @@ Reboot the NanoKVM device itself.
 
 Parameters:
 
-- none
+- `host`: optional target host; required when multiple NanoKVM devices are configured
 
 Example:
 
 ```yaml
 service: nanokvm.reboot
-data: {}
+data:
+  host: "192.168.1.50"
 ```
 
 ## `nanokvm.reset_hdmi`
@@ -57,13 +62,14 @@ Reset the HDMI subsystem (primarily relevant for PCIe hardware).
 
 Parameters:
 
-- none
+- `host`: optional target host; required when multiple NanoKVM devices are configured
 
 Example:
 
 ```yaml
 service: nanokvm.reset_hdmi
-data: {}
+data:
+  host: "192.168.1.50"
 ```
 
 ## `nanokvm.reset_hid`
@@ -72,13 +78,14 @@ Reset the HID subsystem.
 
 Parameters:
 
-- none
+- `host`: optional target host; required when multiple NanoKVM devices are configured
 
 Example:
 
 ```yaml
 service: nanokvm.reset_hid
-data: {}
+data:
+  host: "192.168.1.50"
 ```
 
 ## `nanokvm.wake_on_lan`
@@ -87,6 +94,7 @@ Send a Wake-on-LAN packet to a target MAC address.
 
 Parameters:
 
+- `host`: optional target host; required when multiple NanoKVM devices are configured
 - `mac`: target MAC address (required)
 
 Example:
@@ -94,6 +102,7 @@ Example:
 ```yaml
 service: nanokvm.wake_on_lan
 data:
+  host: "192.168.1.50"
   mac: "00:11:22:33:44:55"
 ```
 
@@ -103,6 +112,7 @@ Enable/disable mouse jiggler and choose mode.
 
 Parameters:
 
+- `host`: optional target host; required when multiple NanoKVM devices are configured
 - `enabled`: `true` or `false` (required)
 - `mode`: `absolute` or `relative` (optional, default `absolute`)
 
@@ -111,6 +121,7 @@ Example:
 ```yaml
 service: nanokvm.set_mouse_jiggler
 data:
+  host: "192.168.1.50"
   enabled: true
   mode: absolute
 ```

--- a/custom_components/nanokvm/services.py
+++ b/custom_components/nanokvm/services.py
@@ -7,6 +7,7 @@ from collections.abc import Awaitable, Callable
 import voluptuous as vol
 
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
 
 from nanokvm.client import NanoKVMClient
 from nanokvm.models import GpioType, MouseJigglerMode
@@ -30,6 +31,8 @@ from .const import (
     SERVICE_SET_MOUSE_JIGGLER,
     SERVICE_WAKE_ON_LAN,
 )
+from .coordinator import NanoKVMDataUpdateCoordinator
+from .utils import normalize_host
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,8 +46,12 @@ _SERVICE_NAMES = (
     SERVICE_SET_MOUSE_JIGGLER,
 )
 
+_OPTIONAL_HOST_FIELD = {
+    vol.Optional(CONF_HOST): vol.All(str, vol.Length(min=1)),
+}
+
 PUSH_BUTTON_SCHEMA = vol.Schema(
-    {
+    _OPTIONAL_HOST_FIELD | {
         vol.Required(ATTR_BUTTON_TYPE): vol.In([BUTTON_TYPE_POWER, BUTTON_TYPE_RESET]),
         vol.Optional(ATTR_DURATION, default=100): vol.All(
             vol.Coerce(int), vol.Range(min=100, max=5000)
@@ -53,19 +60,19 @@ PUSH_BUTTON_SCHEMA = vol.Schema(
 )
 
 PASTE_TEXT_SCHEMA = vol.Schema(
-    {
+    _OPTIONAL_HOST_FIELD | {
         vol.Required(ATTR_TEXT): str,
     }
 )
 
 WAKE_ON_LAN_SCHEMA = vol.Schema(
-    {
+    _OPTIONAL_HOST_FIELD | {
         vol.Required(ATTR_MAC): str,
     }
 )
 
 SET_MOUSE_JIGGLER_SCHEMA = vol.Schema(
-    {
+    _OPTIONAL_HOST_FIELD | {
         vol.Required(ATTR_ENABLED): bool,
         vol.Optional(
             ATTR_MODE, default=MouseJigglerMode.ABSOLUTE.value
@@ -73,27 +80,66 @@ SET_MOUSE_JIGGLER_SCHEMA = vol.Schema(
     }
 )
 
+HOST_ONLY_SCHEMA = vol.Schema(_OPTIONAL_HOST_FIELD)
+
 
 def async_register_services(hass: HomeAssistant) -> None:
     """Register integration services."""
     if hass.services.has_service(DOMAIN, SERVICE_PUSH_BUTTON):
         return
 
+    def _resolve_target_coordinator(call: ServiceCall) -> NanoKVMDataUpdateCoordinator:
+        """Resolve the single NanoKVM device targeted by a service call."""
+        coordinators = list(hass.data.get(DOMAIN, {}).values())
+        if not coordinators:
+            raise HomeAssistantError("No NanoKVM devices are configured")
+
+        requested_host = call.data.get(CONF_HOST)
+        if requested_host is None:
+            if len(coordinators) == 1:
+                return coordinators[0]
+            raise HomeAssistantError(
+                "Multiple NanoKVM devices are configured; specify the host field to target one device"
+            )
+
+        normalized_requested_host = normalize_host(requested_host)
+        matches = [
+            coordinator
+            for coordinator in coordinators
+            if normalize_host(coordinator.config_entry.data[CONF_HOST])
+            == normalized_requested_host
+        ]
+
+        if not matches:
+            raise HomeAssistantError(f"No NanoKVM device is configured for host {requested_host}")
+
+        if len(matches) > 1:
+            raise HomeAssistantError(
+                f"Multiple NanoKVM devices match host {requested_host}; fix the duplicate configuration before calling this service"
+            )
+
+        return matches[0]
+
     async def _execute_service(
+        call: ServiceCall,
         service_name: str,
         handler: Callable[[NanoKVMClient, str], Awaitable[None]],
     ) -> None:
-        """Execute a service on all configured NanoKVM devices."""
-        for coordinator in hass.data.get(DOMAIN, {}).values():
-            client = coordinator.client
-            host = coordinator.config_entry.data.get(CONF_HOST, "<unknown>")
-            try:
-                async with client:
-                    await handler(client, host)
-            except Exception as err:
-                _LOGGER.error(
-                    "Error executing %s service for %s: %s", service_name, host, err
-                )
+        """Execute a service on the targeted NanoKVM device."""
+        coordinator = _resolve_target_coordinator(call)
+        client = coordinator.client
+        host = coordinator.config_entry.data.get(CONF_HOST, "<unknown>")
+
+        try:
+            async with client:
+                await handler(client, host)
+        except Exception as err:
+            _LOGGER.error(
+                "Error executing %s service for %s: %s", service_name, host, err
+            )
+            raise HomeAssistantError(
+                f"Failed to execute {service_name} for {host}: {err}"
+            ) from err
 
     async def handle_push_button(call: ServiceCall) -> None:
         """Handle the push button service."""
@@ -105,7 +151,7 @@ def async_register_services(hass: HomeAssistant) -> None:
             await client.push_button(gpio_type, duration)
             _LOGGER.debug("Button %s pushed for %d ms on %s", button_type, duration, host)
 
-        await _execute_service(SERVICE_PUSH_BUTTON, service_logic)
+        await _execute_service(call, SERVICE_PUSH_BUTTON, service_logic)
 
     async def handle_paste_text(call: ServiceCall) -> None:
         """Handle the paste text service."""
@@ -115,34 +161,34 @@ def async_register_services(hass: HomeAssistant) -> None:
             await client.paste_text(text)
             _LOGGER.debug("Text pasted on %s", host)
 
-        await _execute_service(SERVICE_PASTE_TEXT, service_logic)
+        await _execute_service(call, SERVICE_PASTE_TEXT, service_logic)
 
-    async def handle_reboot(_: ServiceCall) -> None:
+    async def handle_reboot(call: ServiceCall) -> None:
         """Handle the reboot service."""
 
         async def service_logic(client: NanoKVMClient, host: str) -> None:
             await client.reboot_system()
             _LOGGER.debug("System reboot initiated on %s", host)
 
-        await _execute_service(SERVICE_REBOOT, service_logic)
+        await _execute_service(call, SERVICE_REBOOT, service_logic)
 
-    async def handle_reset_hdmi(_: ServiceCall) -> None:
+    async def handle_reset_hdmi(call: ServiceCall) -> None:
         """Handle the reset HDMI service."""
 
         async def service_logic(client: NanoKVMClient, host: str) -> None:
             await client.reset_hdmi()
             _LOGGER.debug("HDMI reset initiated on %s", host)
 
-        await _execute_service(SERVICE_RESET_HDMI, service_logic)
+        await _execute_service(call, SERVICE_RESET_HDMI, service_logic)
 
-    async def handle_reset_hid(_: ServiceCall) -> None:
+    async def handle_reset_hid(call: ServiceCall) -> None:
         """Handle the reset HID service."""
 
         async def service_logic(client: NanoKVMClient, host: str) -> None:
             await client.reset_hid()
             _LOGGER.debug("HID reset initiated on %s", host)
 
-        await _execute_service(SERVICE_RESET_HID, service_logic)
+        await _execute_service(call, SERVICE_RESET_HID, service_logic)
 
     async def handle_wake_on_lan(call: ServiceCall) -> None:
         """Handle the wake on LAN service."""
@@ -152,7 +198,7 @@ def async_register_services(hass: HomeAssistant) -> None:
             await client.send_wake_on_lan(mac)
             _LOGGER.debug("Wake on LAN packet sent to %s via %s", mac, host)
 
-        await _execute_service(SERVICE_WAKE_ON_LAN, service_logic)
+        await _execute_service(call, SERVICE_WAKE_ON_LAN, service_logic)
 
     async def handle_set_mouse_jiggler(call: ServiceCall) -> None:
         """Handle the set mouse jiggler service."""
@@ -170,7 +216,7 @@ def async_register_services(hass: HomeAssistant) -> None:
                 "Mouse jiggler on %s set to %s with mode %s", host, enabled, mode_str
             )
 
-        await _execute_service(SERVICE_SET_MOUSE_JIGGLER, service_logic)
+        await _execute_service(call, SERVICE_SET_MOUSE_JIGGLER, service_logic)
 
     hass.services.async_register(
         DOMAIN, SERVICE_PUSH_BUTTON, handle_push_button, schema=PUSH_BUTTON_SCHEMA
@@ -178,9 +224,15 @@ def async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN, SERVICE_PASTE_TEXT, handle_paste_text, schema=PASTE_TEXT_SCHEMA
     )
-    hass.services.async_register(DOMAIN, SERVICE_REBOOT, handle_reboot)
-    hass.services.async_register(DOMAIN, SERVICE_RESET_HDMI, handle_reset_hdmi)
-    hass.services.async_register(DOMAIN, SERVICE_RESET_HID, handle_reset_hid)
+    hass.services.async_register(
+        DOMAIN, SERVICE_REBOOT, handle_reboot, schema=HOST_ONLY_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_RESET_HDMI, handle_reset_hdmi, schema=HOST_ONLY_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_RESET_HID, handle_reset_hid, schema=HOST_ONLY_SCHEMA
+    )
     hass.services.async_register(
         DOMAIN, SERVICE_WAKE_ON_LAN, handle_wake_on_lan, schema=WAKE_ON_LAN_SCHEMA
     )

--- a/custom_components/nanokvm/services.yaml
+++ b/custom_components/nanokvm/services.yaml
@@ -2,6 +2,11 @@ push_button:
   name: Push Button
   description: Simulate pushing a hardware button on the NanoKVM device.
   fields:
+    host:
+      name: Host
+      description: Optional target host. Required when multiple NanoKVM devices are configured.
+      selector:
+        text:
     button_type:
       name: Button Type
       description: The type of button to push (power or reset).
@@ -25,6 +30,11 @@ paste_text:
   name: Paste Text
   description: Paste text via HID keyboard simulation.
   fields:
+    host:
+      name: Host
+      description: Optional target host. Required when multiple NanoKVM devices are configured.
+      selector:
+        text:
     text:
       name: Text
       description: The text to paste. Only ASCII printable characters are supported.
@@ -36,19 +46,42 @@ paste_text:
 reboot:
   name: Reboot System
   description: Reboot the NanoKVM device.
+  fields:
+    host:
+      name: Host
+      description: Optional target host. Required when multiple NanoKVM devices are configured.
+      selector:
+        text:
 
 reset_hdmi:
   name: Reset HDMI
   description: Reset the HDMI connection (relevant for PCIe version).
+  fields:
+    host:
+      name: Host
+      description: Optional target host. Required when multiple NanoKVM devices are configured.
+      selector:
+        text:
 
 reset_hid:
   name: Reset HID
   description: Reset the HID subsystem.
+  fields:
+    host:
+      name: Host
+      description: Optional target host. Required when multiple NanoKVM devices are configured.
+      selector:
+        text:
 
 wake_on_lan:
   name: Wake on LAN
   description: Send a Wake-on-LAN packet to the specified MAC address.
   fields:
+    host:
+      name: Host
+      description: Optional target host. Required when multiple NanoKVM devices are configured.
+      selector:
+        text:
     mac:
       name: MAC Address
       description: The MAC address to send the Wake-on-LAN packet to.
@@ -61,6 +94,11 @@ set_mouse_jiggler:
   name: Set Mouse Jiggler
   description: Configure the mouse jiggler state and mode.
   fields:
+    host:
+      name: Host
+      description: Optional target host. Required when multiple NanoKVM devices are configured.
+      selector:
+        text:
     enabled:
       name: Enabled
       description: Enable or disable the mouse jiggler.

--- a/custom_components/nanokvm/translations/en.json
+++ b/custom_components/nanokvm/translations/en.json
@@ -218,6 +218,10 @@
       "name": "Push Button",
       "description": "Simulate pushing a hardware button on the NanoKVM device.",
       "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Optional target host. Required when multiple NanoKVM devices are configured."
+        },
         "button_type": {
           "name": "Button Type",
           "description": "The type of button to push (power or reset)."
@@ -232,6 +236,10 @@
       "name": "Paste Text",
       "description": "Paste text via HID keyboard simulation.",
       "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Optional target host. Required when multiple NanoKVM devices are configured."
+        },
         "text": {
           "name": "Text",
           "description": "The text to paste. Only ASCII printable characters are supported."
@@ -240,20 +248,42 @@
     },
     "reboot": {
       "name": "Reboot System",
-      "description": "Reboot the NanoKVM device."
+      "description": "Reboot the NanoKVM device.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Optional target host. Required when multiple NanoKVM devices are configured."
+        }
+      }
     },
     "reset_hdmi": {
       "name": "Reset HDMI",
-      "description": "Reset the HDMI connection (relevant for PCIe version)."
+      "description": "Reset the HDMI connection (relevant for PCIe version).",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Optional target host. Required when multiple NanoKVM devices are configured."
+        }
+      }
     },
     "reset_hid": {
       "name": "Reset HID",
-      "description": "Reset the HID subsystem."
+      "description": "Reset the HID subsystem.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Optional target host. Required when multiple NanoKVM devices are configured."
+        }
+      }
     },
     "wake_on_lan": {
       "name": "Wake on LAN",
       "description": "Send a Wake-on-LAN packet to the specified MAC address.",
       "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Optional target host. Required when multiple NanoKVM devices are configured."
+        },
         "mac": {
           "name": "MAC Address",
           "description": "The MAC address to send the Wake-on-LAN packet to."
@@ -264,6 +294,10 @@
       "name": "Set Mouse Jiggler",
       "description": "Configure the mouse jiggler state and mode.",
       "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Optional target host. Required when multiple NanoKVM devices are configured."
+        },
         "enabled": {
           "name": "Enabled",
           "description": "Enable or disable the mouse jiggler."

--- a/custom_components/nanokvm/translations/fr.json
+++ b/custom_components/nanokvm/translations/fr.json
@@ -218,6 +218,10 @@
       "name": "Appuyer sur un bouton",
       "description": "Simuler l'appui sur un bouton matériel de l'appareil NanoKVM.",
       "fields": {
+        "host": {
+          "name": "Hôte",
+          "description": "Hôte cible facultatif. Obligatoire lorsque plusieurs appareils NanoKVM sont configurés."
+        },
         "button_type": {
           "name": "Type de bouton",
           "description": "Le type de bouton sur lequel appuyer (alimentation ou réinitialisation)."
@@ -232,6 +236,10 @@
       "name": "Coller du texte",
       "description": "Coller du texte via la simulation de clavier HID.",
       "fields": {
+        "host": {
+          "name": "Hôte",
+          "description": "Hôte cible facultatif. Obligatoire lorsque plusieurs appareils NanoKVM sont configurés."
+        },
         "text": {
           "name": "Texte",
           "description": "Le texte à coller. Seuls les caractères ASCII imprimables sont pris en charge."
@@ -240,20 +248,42 @@
     },
     "reboot": {
       "name": "Redémarrer le système",
-      "description": "Redémarrer l'appareil NanoKVM."
+      "description": "Redémarrer l'appareil NanoKVM.",
+      "fields": {
+        "host": {
+          "name": "Hôte",
+          "description": "Hôte cible facultatif. Obligatoire lorsque plusieurs appareils NanoKVM sont configurés."
+        }
+      }
     },
     "reset_hdmi": {
       "name": "Réinitialiser HDMI",
-      "description": "Réinitialiser la connexion HDMI (pertinent pour la version PCIe)."
+      "description": "Réinitialiser la connexion HDMI (pertinent pour la version PCIe).",
+      "fields": {
+        "host": {
+          "name": "Hôte",
+          "description": "Hôte cible facultatif. Obligatoire lorsque plusieurs appareils NanoKVM sont configurés."
+        }
+      }
     },
     "reset_hid": {
       "name": "Réinitialiser HID",
-      "description": "Réinitialiser le sous-système HID."
+      "description": "Réinitialiser le sous-système HID.",
+      "fields": {
+        "host": {
+          "name": "Hôte",
+          "description": "Hôte cible facultatif. Obligatoire lorsque plusieurs appareils NanoKVM sont configurés."
+        }
+      }
     },
     "wake_on_lan": {
       "name": "Wake on LAN",
       "description": "Envoyer un paquet Wake-on-LAN à l'adresse MAC spécifiée.",
       "fields": {
+        "host": {
+          "name": "Hôte",
+          "description": "Hôte cible facultatif. Obligatoire lorsque plusieurs appareils NanoKVM sont configurés."
+        },
         "mac": {
           "name": "Adresse MAC",
           "description": "L'adresse MAC à laquelle envoyer le paquet Wake-on-LAN."
@@ -264,6 +294,10 @@
       "name": "Définir l'agitateur de souris",
       "description": "Configurer l'état et le mode de l'agitateur de souris.",
       "fields": {
+        "host": {
+          "name": "Hôte",
+          "description": "Hôte cible facultatif. Obligatoire lorsque plusieurs appareils NanoKVM sont configurés."
+        },
         "enabled": {
           "name": "Activé",
           "description": "Activer ou désactiver l'agitateur de souris."

--- a/custom_components/nanokvm/translations/pt-BR.json
+++ b/custom_components/nanokvm/translations/pt-BR.json
@@ -218,6 +218,10 @@
       "name": "Pressionar Botão",
       "description": "Simula pressionar um botão físico no dispositivo NanoKVM.",
       "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Host de destino opcional. Obrigatório quando vários dispositivos NanoKVM estiverem configurados."
+        },
         "button_type": {
           "name": "Tipo de Botão",
           "description": "O tipo de botão a ser pressionado (power ou reset)."
@@ -232,6 +236,10 @@
       "name": "Colar Texto",
       "description": "Cola texto via simulação de teclado HID.",
       "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Host de destino opcional. Obrigatório quando vários dispositivos NanoKVM estiverem configurados."
+        },
         "text": {
           "name": "Texto",
           "description": "O texto a ser colado. Apenas caracteres ASCII imprimíveis são suportados."
@@ -240,20 +248,42 @@
     },
     "reboot": {
       "name": "Reiniciar Sistema",
-      "description": "Reinicia o dispositivo NanoKVM."
+      "description": "Reinicia o dispositivo NanoKVM.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Host de destino opcional. Obrigatório quando vários dispositivos NanoKVM estiverem configurados."
+        }
+      }
     },
     "reset_hdmi": {
       "name": "Resetar HDMI",
-      "description": "Reseta a conexão HDMI (relevante para versão PCIe)."
+      "description": "Reseta a conexão HDMI (relevante para versão PCIe).",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Host de destino opcional. Obrigatório quando vários dispositivos NanoKVM estiverem configurados."
+        }
+      }
     },
     "reset_hid": {
       "name": "Resetar HID",
-      "description": "Reseta o subsistema HID."
+      "description": "Reseta o subsistema HID.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Host de destino opcional. Obrigatório quando vários dispositivos NanoKVM estiverem configurados."
+        }
+      }
     },
     "wake_on_lan": {
       "name": "Wake on LAN",
       "description": "Envia um pacote Wake-on-LAN para o endereço MAC especificado.",
       "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Host de destino opcional. Obrigatório quando vários dispositivos NanoKVM estiverem configurados."
+        },
         "mac": {
           "name": "Endereço MAC",
           "description": "O endereço MAC para o qual enviar o pacote Wake-on-LAN."
@@ -264,6 +294,10 @@
       "name": "Definir Mouse Jiggler",
       "description": "Define o modo do mouse jiggler.",
       "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Host de destino opcional. Obrigatório quando vários dispositivos NanoKVM estiverem configurados."
+        },
         "enabled": {
           "name": "Ativado",
           "description": "Ativa ou desativa o mouse jiggler."


### PR DESCRIPTION
## Summary

This PR fixes the current `nanokvm.*` service behavior where a single service call is executed against every configured NanoKVM device.

Services now resolve exactly one target device:
- If only one NanoKVM is configured, `host` remains optional and the service targets that device automatically.
- If multiple NanoKVM devices are configured, the caller must provide `host`.
- Service calls now raise a clear error when `host` is missing in a multi-device setup, does not match any configured device, or matches multiple entries.

This PR also updates the service schemas, Home Assistant service metadata, docs, and translations to expose the new optional `host` field and document the targeting behavior.
