### PR TITLE
fix: stabilize ssh sensor lifecycle

### DIFF
--- a/custom_components/nanokvm/coordinator.py
+++ b/custom_components/nanokvm/coordinator.py
@@ -237,6 +237,15 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
             "hostname_info": self.hostname_info,
         }
 
+    def _clear_ssh_metrics(self) -> None:
+        """Clear SSH-derived metrics from the coordinator."""
+        self.uptime = None
+        self.cpu_temperature = None
+        self.memory_total = None
+        self.memory_used_percent = None
+        self.storage_total = None
+        self.storage_used_percent = None
+
     async def _async_update_ssh_data(self) -> None:
         """Fetch data via SSH."""
         if not self.ssh_metrics_collector:
@@ -268,20 +277,13 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
 
         except Exception as err:
             _LOGGER.debug("Failed to fetch data via SSH: %s", err)
-            self.uptime = None
-            self.cpu_temperature = None
+            self._clear_ssh_metrics()
             if self.ssh_metrics_collector:
                 await self.ssh_metrics_collector.disconnect()
 
     async def _async_clear_ssh_data(self) -> None:
         """Clear SSH data and disconnect client."""
-        self.uptime = None
-        self.cpu_temperature = None
-        self.memory_total = None
-        self.memory_used_percent = None
-        self.storage_total = None
-        self.storage_used_percent = None
-        self.ssh_sensors_created = False
+        self._clear_ssh_metrics()
         if self.ssh_metrics_collector:
             await self.ssh_metrics_collector.disconnect()
             self.ssh_metrics_collector = None

--- a/custom_components/nanokvm/sensor.py
+++ b/custom_components/nanokvm/sensor.py
@@ -183,21 +183,17 @@ async def async_setup_entry(
         if description.should_create_fn(coordinator)
     )
 
-    if coordinator.ssh_state and coordinator.ssh_state.enabled:
-        _LOGGER.debug("SSH already enabled, creating SSH sensors")
-        async_add_entities(
-            NanoKVMSensor(
-                coordinator=coordinator,
-                description=description,
-            )
-            for description in SSH_SENSORS
-        )
-        coordinator.ssh_sensors_created = True
+    ssh_entities_added = False
 
     @callback
     def async_add_ssh_sensors() -> None:
         """Add SSH sensors when SSH is enabled."""
-        _LOGGER.debug("Received signal to create SSH sensors")
+        nonlocal ssh_entities_added
+        if ssh_entities_added:
+            _LOGGER.debug("SSH sensors already registered, ignoring create signal")
+            return
+
+        _LOGGER.debug("Creating SSH sensors")
         async_add_entities(
             NanoKVMSensor(
                 coordinator=coordinator,
@@ -205,6 +201,12 @@ async def async_setup_entry(
             )
             for description in SSH_SENSORS
         )
+        ssh_entities_added = True
+        coordinator.ssh_sensors_created = True
+
+    if coordinator.ssh_state and coordinator.ssh_state.enabled:
+        _LOGGER.debug("SSH already enabled during setup, creating SSH sensors")
+        async_add_ssh_sensors()
 
     entry.async_on_unload(
         async_dispatcher_connect(


### PR DESCRIPTION
## Summary

This PR fixes two SSH-related issues in the NanoKVM integration.

First, it prevents duplicate SSH sensor creation attempts when SSH is toggled off and back on. Previously, the coordinator could emit the "create SSH sensors" signal again after SSH was disabled, and the sensor platform would blindly try to add the same entities a second time. This could cause duplicate-add errors or unnecessary log noise.

Second, it prevents stale SSH-derived metrics from remaining in Home Assistant after SSH metric collection fails. Previously, a failed SSH refresh only cleared `uptime` and `cpu_temperature`, while memory and storage values could remain stuck at their last successful values.

This change:
- makes SSH sensor registration idempotent in the sensor platform
- keeps SSH sensor entities registered once they have been created
- clears all SSH-derived metrics on SSH collection failures
- reuses the same SSH metric clearing path when SSH is disabled
