### PR TITLE
fix: create media entities only when needed

### DIFF
--- a/custom_components/nanokvm/binary_sensor.py
+++ b/custom_components/nanokvm/binary_sensor.py
@@ -11,7 +11,8 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from nanokvm.models import HWVersion
@@ -20,6 +21,7 @@ from .const import (
     DOMAIN,
     ICON_DISK,
     ICON_POWER,
+    SIGNAL_NEW_MEDIA_ENTITIES,
     ICON_WIFI,
 )
 from .coordinator import NanoKVMDataUpdateCoordinator
@@ -59,6 +61,21 @@ def _has_mounted_image(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
     return bool(coordinator.mounted_image and coordinator.mounted_image.file != "")
 
 
+MEDIA_BINARY_SENSORS: tuple[NanoKVMBinarySensorEntityDescription, ...] = (
+    NanoKVMBinarySensorEntityDescription(
+        key="cdrom_mode",
+        name="CD-ROM Mode",
+        translation_key="cdrom_mode",
+        icon=ICON_DISK,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coordinator: bool(
+            coordinator.cdrom_status and coordinator.cdrom_status.cdrom == 1
+        ),
+        available_fn=_has_mounted_image,
+    ),
+)
+
+
 BINARY_SENSORS: tuple[NanoKVMBinarySensorEntityDescription, ...] = (
     NanoKVMBinarySensorEntityDescription(
         key="power_led",
@@ -94,17 +111,6 @@ BINARY_SENSORS: tuple[NanoKVMBinarySensorEntityDescription, ...] = (
         available_fn=_wifi_supported,
         should_create_fn=_wifi_supported,
     ),
-    NanoKVMBinarySensorEntityDescription(
-        key="cdrom_mode",
-        name="CD-ROM Mode",
-        translation_key="cdrom_mode",
-        icon=ICON_DISK,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda coordinator: bool(
-            coordinator.cdrom_status and coordinator.cdrom_status.cdrom == 1
-        ),
-        available_fn=_has_mounted_image,
-    ),
 )
 
 
@@ -123,6 +129,37 @@ async def async_setup_entry(
         )
         for description in BINARY_SENSORS
         if description.should_create_fn(coordinator)
+    )
+
+    media_entities_added = False
+
+    @callback
+    def async_add_media_binary_sensors() -> None:
+        """Add media-backed binary sensors when media is first mounted."""
+        nonlocal media_entities_added
+        if media_entities_added:
+            return
+        if not _has_mounted_image(coordinator):
+            return
+
+        async_add_entities(
+            NanoKVMBinarySensor(
+                coordinator=coordinator,
+                description=description,
+            )
+            for description in MEDIA_BINARY_SENSORS
+        )
+        media_entities_added = True
+
+    if _has_mounted_image(coordinator):
+        async_add_media_binary_sensors()
+
+    entry.async_on_unload(
+        async_dispatcher_connect(
+            hass,
+            SIGNAL_NEW_MEDIA_ENTITIES.format(entry.entry_id),
+            async_add_media_binary_sensors,
+        )
     )
 
 

--- a/custom_components/nanokvm/const.py
+++ b/custom_components/nanokvm/const.py
@@ -57,3 +57,4 @@ ICON_HDMI = "mdi:video-input-hdmi"
 
 # Signals
 SIGNAL_NEW_SSH_SENSORS = "nanokvm_new_ssh_sensors_{}"
+SIGNAL_NEW_MEDIA_ENTITIES = "nanokvm_new_media_entities_{}"

--- a/custom_components/nanokvm/coordinator.py
+++ b/custom_components/nanokvm/coordinator.py
@@ -23,7 +23,13 @@ from nanokvm.client import (
 )
 from nanokvm.models import GetCdRomRsp, GetInfoRsp, GetMountedImageRsp, HidMode
 
-from .const import CONF_USE_STATIC_HOST, DEFAULT_SCAN_INTERVAL, DOMAIN, SIGNAL_NEW_SSH_SENSORS
+from .const import (
+    CONF_USE_STATIC_HOST,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    SIGNAL_NEW_MEDIA_ENTITIES,
+    SIGNAL_NEW_SSH_SENSORS,
+)
 from .ssh_metrics import SSHMetricsCollector
 from .utils import extract_ssh_host, normalize_host
 
@@ -73,6 +79,7 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         self.memory_used_percent = None
         self.storage_total = None
         self.storage_used_percent = None
+        self.media_entities_created = False
         self.ssh_sensors_created = False
         self.ssh_metrics_collector = None
         self.hostname_info = None
@@ -152,6 +159,7 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
 
             await self._async_fetch_core_data()
             await self._async_fetch_storage_data()
+            self._async_maybe_create_media_entities()
             await self._async_refresh_ssh_data()
             return self._build_update_data()
 
@@ -245,6 +253,18 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         self.memory_used_percent = None
         self.storage_total = None
         self.storage_used_percent = None
+
+    def _async_maybe_create_media_entities(self) -> None:
+        """Signal when media-backed entities should be created."""
+        if self.media_entities_created:
+            return
+
+        if self.mounted_image and self.mounted_image.file != "":
+            _LOGGER.debug("Mounted image present, signaling to create media entities")
+            async_dispatcher_send(
+                self.hass, SIGNAL_NEW_MEDIA_ENTITIES.format(self.config_entry.entry_id)
+            )
+            self.media_entities_created = True
 
     async def _async_update_ssh_data(self) -> None:
         """Fetch data via SSH."""

--- a/custom_components/nanokvm/sensor.py
+++ b/custom_components/nanokvm/sensor.py
@@ -24,6 +24,7 @@ from .const import (
     ICON_DISK,
     ICON_IMAGE,
     ICON_NETWORK,
+    SIGNAL_NEW_MEDIA_ENTITIES,
     ICON_SSH,
     SIGNAL_NEW_SSH_SENSORS,
 )
@@ -94,7 +95,7 @@ class NanoKVMSensorEntityDescription(SensorEntityDescription):
     attributes_fn: Callable[[NanoKVMDataUpdateCoordinator], dict[str, Any]] = lambda _: {}
 
 
-SENSORS: tuple[NanoKVMSensorEntityDescription, ...] = (
+MEDIA_SENSORS: tuple[NanoKVMSensorEntityDescription, ...] = (
     NanoKVMSensorEntityDescription(
         key="mounted_image",
         name="Mounted Image",
@@ -102,8 +103,12 @@ SENSORS: tuple[NanoKVMSensorEntityDescription, ...] = (
         icon=ICON_IMAGE,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=_mounted_image_value,
+        should_create_fn=_has_mounted_image,
         available_fn=_has_mounted_image,
     ),
+)
+
+SENSORS: tuple[NanoKVMSensorEntityDescription, ...] = (
     NanoKVMSensorEntityDescription(
         key="tailscale_state",
         name="Tailscale",
@@ -182,6 +187,32 @@ async def async_setup_entry(
         if description.should_create_fn(coordinator)
     )
 
+    media_entities_added = False
+
+    @callback
+    def async_add_media_sensors() -> None:
+        """Add media-backed sensors when media is first mounted."""
+        nonlocal media_entities_added
+        if media_entities_added:
+            _LOGGER.debug("Media sensors already registered, ignoring create signal")
+            return
+        if not _has_mounted_image(coordinator):
+            return
+
+        _LOGGER.debug("Creating media sensors")
+        async_add_entities(
+            NanoKVMSensor(
+                coordinator=coordinator,
+                description=description,
+            )
+            for description in MEDIA_SENSORS
+        )
+        media_entities_added = True
+
+    if _has_mounted_image(coordinator):
+        _LOGGER.debug("Mounted image already present during setup, creating media sensors")
+        async_add_media_sensors()
+
     ssh_entities_added = False
 
     @callback
@@ -207,6 +238,11 @@ async def async_setup_entry(
         _LOGGER.debug("SSH already enabled during setup, creating SSH sensors")
         async_add_ssh_sensors()
 
+    entry.async_on_unload(
+        async_dispatcher_connect(
+            hass, SIGNAL_NEW_MEDIA_ENTITIES.format(entry.entry_id), async_add_media_sensors
+        )
+    )
     entry.async_on_unload(
         async_dispatcher_connect(
             hass, SIGNAL_NEW_SSH_SENSORS.format(entry.entry_id), async_add_ssh_sensors


### PR DESCRIPTION
## Summary

This PR fixes the lifecycle of the mounted-image sensor and CD-ROM binary sensor.

Previously, these entities had two bad behaviors:
- if no ISO was mounted during startup, they could be skipped permanently
- if they were always created up front, they appeared as unavailable even when they were not relevant yet

This change switches them to lazy creation:
- if media is already mounted during setup, the entities are created immediately
- if media is mounted later, the coordinator emits a one-time signal and the entities are created at that point
- once created, the entities remain registered and can transition between available and unavailable as media is mounted or unmounted

This keeps the entities discoverable once they matter, without cluttering Home Assistant with unnecessary unavailable entities before that.
