### PR TITLE
Add reauthentication flow for invalid NanoKVM credentials

### DIFF
--- a/custom_components/nanokvm/__init__.py
+++ b/custom_components/nanokvm/__init__.py
@@ -9,7 +9,7 @@ import aiohttp
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 
 from nanokvm.client import NanoKVMAuthenticationFailure, NanoKVMClient, NanoKVMError
 
@@ -51,8 +51,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             await client.authenticate(username, password)
             device_info = await client.get_info()
     except NanoKVMAuthenticationFailure as err:
-        _LOGGER.error("Authentication failed: %s", err)
-        return False
+        raise ConfigEntryAuthFailed(
+            f"Authentication failed for NanoKVM at {host}"
+        ) from err
     except (aiohttp.ClientError, NanoKVMError, asyncio.TimeoutError) as err:
         raise ConfigEntryNotReady(f"Failed to fetch initial device info: {err}") from err
 

--- a/custom_components/nanokvm/config_flow.py
+++ b/custom_components/nanokvm/config_flow.py
@@ -15,7 +15,13 @@ from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from nanokvm.client import NanoKVMClient, NanoKVMAuthenticationFailure, NanoKVMError
 
-from .const import DEFAULT_USERNAME, DEFAULT_PASSWORD, DOMAIN, INTEGRATION_TITLE, CONF_USE_STATIC_HOST
+from .const import (
+    CONF_USE_STATIC_HOST,
+    DEFAULT_PASSWORD,
+    DEFAULT_USERNAME,
+    DOMAIN,
+    INTEGRATION_TITLE,
+)
 from .utils import normalize_host, normalize_mdns
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,6 +45,13 @@ class NanoKVMConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Sipeed NanoKVM."""
 
     VERSION = 1
+
+    def _get_reauth_entry(self) -> ConfigEntry:
+        """Return the config entry currently undergoing reauthentication."""
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        if entry is None:
+            raise RuntimeError("Reauth flow started for a missing NanoKVM entry")
+        return entry
 
     def _async_find_matching_entry(self, *unique_ids: str) -> ConfigEntry | None:
         """Find an existing config entry by any of the provided unique IDs."""
@@ -116,6 +129,74 @@ class NanoKVMConfigFlow(ConfigFlow, domain=DOMAIN):
             )
 
         return self.async_create_entry(title=INTEGRATION_TITLE, data=data)
+
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
+        """Start a reauthentication flow for an existing entry."""
+        del entry_data
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Update stored credentials for an existing NanoKVM entry."""
+        entry = self._get_reauth_entry()
+        errors: dict[str, str] = {}
+
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_USERNAME,
+                    default=entry.data.get(CONF_USERNAME, DEFAULT_USERNAME),
+                ): str,
+                vol.Required(CONF_PASSWORD): str,
+            }
+        )
+
+        if user_input is not None:
+            data = entry.data | user_input
+
+            try:
+                device_key = await validate_input(data)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(device_key)
+
+                existing_entry = self._async_find_matching_entry(device_key)
+                if (
+                    existing_entry is not None
+                    and existing_entry.entry_id != entry.entry_id
+                ):
+                    return self.async_abort(reason="already_configured")
+
+                update_kwargs: dict[str, Any] = {
+                    "data_updates": {
+                        CONF_USERNAME: user_input[CONF_USERNAME],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    },
+                }
+                if entry.unique_id != device_key:
+                    update_kwargs["unique_id"] = device_key
+
+                return self.async_update_reload_and_abort(
+                    entry,
+                    reason="reauth_successful",
+                    **update_kwargs,
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=schema,
+            errors=errors,
+            description_placeholders={
+                "name": entry.data.get(CONF_HOST, INTEGRATION_TITLE),
+            },
+        )
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/nanokvm/coordinator.py
+++ b/custom_components/nanokvm/coordinator.py
@@ -14,6 +14,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed
 
 from nanokvm.client import (
     NanoKVMApiError,
@@ -38,6 +39,13 @@ _LOGGER = logging.getLogger(__name__)
 _UPDATE_MAX_ATTEMPTS = 3
 _UPDATE_RETRY_DELAY_SECONDS = 1
 _UPDATE_TIMEOUT_SECONDS = 10
+
+
+def _is_auth_failure(error: Exception) -> bool:
+    """Return whether the exception represents invalid credentials."""
+    return isinstance(error, NanoKVMAuthenticationFailure) or (
+        isinstance(error, aiohttp.ClientResponseError) and error.status == 401
+    )
 
 
 class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
@@ -132,17 +140,18 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             return await self._async_fetch_with_client()
         except (aiohttp.ClientResponseError, NanoKVMAuthenticationFailure) as err:
-            if (
-                (
-                    isinstance(err, NanoKVMAuthenticationFailure)
-                    or (
-                        isinstance(err, aiohttp.ClientResponseError)
-                        and err.status == 401
-                    )
-                )
-            ):
+            if _is_auth_failure(err):
                 await self._async_reauthenticate_client(err)
-                return await self._async_fetch_with_client()
+                try:
+                    return await self._async_fetch_with_client()
+                except (aiohttp.ClientResponseError, NanoKVMAuthenticationFailure) as reauth_err:
+                    if _is_auth_failure(reauth_err):
+                        raise ConfigEntryAuthFailed(
+                            "Stored NanoKVM credentials are no longer valid"
+                        ) from reauth_err
+                    if isinstance(reauth_err, aiohttp.ClientResponseError):
+                        raise UpdateFailed(f"HTTP error with NanoKVM: {reauth_err}") from reauth_err
+                    raise UpdateFailed(f"Authentication failed: {reauth_err}") from reauth_err
 
             if isinstance(err, aiohttp.ClientResponseError):
                 raise UpdateFailed(f"HTTP error with NanoKVM: {err}") from err
@@ -171,7 +180,15 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
             async with new_client:
                 await new_client.authenticate(self.username, self.password)
             self.client = new_client
-        except Exception as auth_err:
+        except (aiohttp.ClientResponseError, NanoKVMAuthenticationFailure) as auth_err:
+            if _is_auth_failure(auth_err):
+                raise ConfigEntryAuthFailed(
+                    "Stored NanoKVM credentials are no longer valid"
+                ) from auth_err
+            if isinstance(auth_err, aiohttp.ClientResponseError):
+                raise UpdateFailed(f"Reauthentication failed: {auth_err}") from auth_err
+            raise UpdateFailed(f"Authentication failed: {auth_err}") from auth_err
+        except (NanoKVMError, aiohttp.ClientError, asyncio.TimeoutError) as auth_err:
             if isinstance(original_error, aiohttp.ClientResponseError):
                 raise UpdateFailed(f"Reauthentication failed: {auth_err}") from auth_err
             raise UpdateFailed(f"Authentication failed: {auth_err}") from auth_err

--- a/custom_components/nanokvm/strings.json
+++ b/custom_components/nanokvm/strings.json
@@ -20,7 +20,14 @@
       "confirm": {
         "title": "Discovered Sipeed NanoKVM",
         "description": "Do you want to set up the NanoKVM device named {name}?"
+      },
+      "reauth_confirm": {
+        "title": "Reauthenticate Sipeed NanoKVM",
+        "description": "The NanoKVM integration needs updated credentials for {name}."
       }
+    },
+    "abort": {
+      "reauth_successful": "Reauthentication was successful"
     },
     "error": {
       "cannot_connect": "Failed to connect",

--- a/custom_components/nanokvm/translations/en.json
+++ b/custom_components/nanokvm/translations/en.json
@@ -20,7 +20,14 @@
       "confirm": {
         "title": "Discovered Sipeed NanoKVM",
         "description": "Do you want to set up the NanoKVM device named {name}?"
+      },
+      "reauth_confirm": {
+        "title": "Reauthenticate Sipeed NanoKVM",
+        "description": "The NanoKVM integration needs updated credentials for {name}."
       }
+    },
+    "abort": {
+      "reauth_successful": "Reauthentication was successful"
     },
     "error": {
       "cannot_connect": "Failed to connect",

--- a/custom_components/nanokvm/translations/fr.json
+++ b/custom_components/nanokvm/translations/fr.json
@@ -20,7 +20,14 @@
       "confirm": {
         "title": "Sipeed NanoKVM découvert",
         "description": "Voulez-vous configurer l'appareil NanoKVM nommé {name} ?"
+      },
+      "reauth_confirm": {
+        "title": "Réauthentifier Sipeed NanoKVM",
+        "description": "L'intégration NanoKVM a besoin d'identifiants mis à jour pour {name}."
       }
+    },
+    "abort": {
+      "reauth_successful": "La réauthentification a réussi"
     },
     "error": {
       "cannot_connect": "Échec de la connexion",

--- a/custom_components/nanokvm/translations/pt-BR.json
+++ b/custom_components/nanokvm/translations/pt-BR.json
@@ -20,7 +20,14 @@
       "confirm": {
         "title": "Sipeed NanoKVM detectado",
         "description": "Deseja configurar o dispositivo NanoKVM chamado {name}?"
+      },
+      "reauth_confirm": {
+        "title": "Reautenticar Sipeed NanoKVM",
+        "description": "A integração NanoKVM precisa de credenciais atualizadas para {name}."
       }
+    },
+    "abort": {
+      "reauth_successful": "A reautenticação foi concluída com sucesso"
     },
     "error": {
       "cannot_connect": "Falha ao conectar",


### PR DESCRIPTION
## Summary

This PR fixes the NanoKVM integration's auth failure handling so invalid stored credentials trigger Home Assistant's reauthentication flow instead of leaving the entry unavailable without a recovery path.

## Changes

- raise `ConfigEntryAuthFailed` during setup when initial NanoKVM authentication fails
- raise `ConfigEntryAuthFailed` during coordinator refresh when token refresh or reauthentication still fails with invalid credentials
- add `async_step_reauth` and `async_step_reauth_confirm` to update credentials on the existing config entry
- preserve the existing entry and reload it after successful reauthentication

## Why

Previously, if the NanoKVM password changed, the integration would retry with the same stored credentials and eventually remain unavailable. Home Assistant expects integrations to surface this case as a reauth flow so the user can recover cleanly.
