### PR TITLE
Unify NanoKVM transport handling across HTTP and HTTPS

### DIFF
--- a/custom_components/nanokvm/__init__.py
+++ b/custom_components/nanokvm/__init__.py
@@ -16,7 +16,7 @@ from nanokvm.client import NanoKVMAuthenticationFailure, NanoKVMClient, NanoKVME
 from .const import CONF_SSL_FINGERPRINT, CONF_USE_STATIC_HOST, DOMAIN
 from .coordinator import NanoKVMDataUpdateCoordinator
 from .services import async_register_services, async_unregister_services
-from .utils import normalize_host
+from .utils import api_connection_options
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,23 +45,50 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     ssl_fingerprint = entry.data.get(CONF_SSL_FINGERPRINT)
-    client = NanoKVMClient(normalize_host(host), ssl_fingerprint=ssl_fingerprint)
+    options = api_connection_options(host, ssl_fingerprint)
+    last_error: Exception | None = None
+    client: NanoKVMClient | None = None
+    device_info = None
 
-    try:
-        async with client:
-            await client.authenticate(username, password)
-            device_info = await client.get_info()
-    except NanoKVMAuthenticationFailure as err:
-        raise ConfigEntryAuthFailed(
-            f"Authentication failed for NanoKVM at {host}"
-        ) from err
-    except (aiohttp.ServerFingerprintMismatch,
-            aiohttp.ClientConnectorCertificateError) as err:
-        raise ConfigEntryAuthFailed(
-            f"SSL certificate changed for NanoKVM at {host}"
-        ) from err
-    except (aiohttp.ClientError, NanoKVMError, asyncio.TimeoutError) as err:
-        raise ConfigEntryNotReady(f"Failed to fetch initial device info: {err}") from err
+    for index, option in enumerate(options):
+        candidate_client = NanoKVMClient(
+            option.base_url,
+            ssl_fingerprint=option.ssl_fingerprint,
+        )
+        try:
+            async with candidate_client:
+                await candidate_client.authenticate(username, password)
+                device_info = await candidate_client.get_info()
+            client = candidate_client
+            break
+        except NanoKVMAuthenticationFailure as err:
+            raise ConfigEntryAuthFailed(
+                f"Authentication failed for NanoKVM at {host}"
+            ) from err
+        except (
+            aiohttp.ServerFingerprintMismatch,
+            aiohttp.ClientConnectorCertificateError,
+        ) as err:
+            if option.scheme == "http" and index < len(options) - 1:
+                last_error = err
+                continue
+            raise ConfigEntryAuthFailed(
+                f"SSL certificate changed for NanoKVM at {host}"
+            ) from err
+        except aiohttp.ClientConnectorError as err:
+            last_error = err
+            if index < len(options) - 1:
+                continue
+            break
+        except (aiohttp.ClientError, NanoKVMError, asyncio.TimeoutError) as err:
+            last_error = err
+            break
+
+    if client is None or device_info is None:
+        assert last_error is not None
+        raise ConfigEntryNotReady(
+            f"Failed to fetch initial device info: {last_error}"
+        ) from last_error
 
     coordinator = NanoKVMDataUpdateCoordinator(
         hass,

--- a/custom_components/nanokvm/camera.py
+++ b/custom_components/nanokvm/camera.py
@@ -14,14 +14,13 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from nanokvm.utils import obfuscate_password
+from nanokvm.client import NanoKVMClient
 from webrtc_models import RTCIceCandidateInit
 
 from .camera_webrtc import NanoKVMWebRTCManager
 from .coordinator import NanoKVMDataUpdateCoordinator
-from .const import DOMAIN, ICON_HDMI
+from .const import CONF_SSL_FINGERPRINT, DOMAIN, ICON_HDMI
 from .entity import NanoKVMEntity
-from .utils import normalize_host
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -88,70 +87,69 @@ class NanoKVMCamera(NanoKVMEntity, Camera):
         self._webrtc = NanoKVMWebRTCManager(
             logger=_LOGGER,
             hass_provider=lambda: self.hass,
-            connection_info_provider=self._stream_connection_info,
-            authenticate_stream=self._authenticate_stream,
+            client_factory=self._create_stream_client,
+            authenticate_client=self._authenticate_stream_client,
             login_timeout_seconds=LOGIN_TIMEOUT_SECONDS,
             websocket_heartbeat_seconds=WEBSOCKET_HEARTBEAT_SECONDS,
             max_pending_ice_candidates=MAX_PENDING_ICE_CANDIDATES,
         )
 
-    def _stream_connection_info(self) -> tuple[str, str, str] | None:
-        """Return normalized base URL and credentials for stream auth/signaling."""
+    def _stream_credentials(self) -> tuple[str, str] | None:
+        """Return configured stream credentials."""
         config_entry = self.coordinator.config_entry
         if not config_entry or not config_entry.data:
             return None
 
-        host = config_entry.data.get("host")
         username = config_entry.data.get("username")
         password = config_entry.data.get("password")
 
-        if not host or not username or not password:
+        if not username or not password:
             return None
 
-        return normalize_host(host), username, password
+        return username, password
 
-    async def _authenticate_stream(
-        self,
-        session: aiohttp.ClientSession,
-        base_url: str,
-        username: str,
-        password: str,
-    ) -> str:
-        """Authenticate directly against NanoKVM API and return JWT token."""
-        async with session.post(
-            f"{base_url}auth/login",
-            json={
-                "username": username,
-                "password": obfuscate_password(password),
-            },
-            timeout=aiohttp.ClientTimeout(total=LOGIN_TIMEOUT_SECONDS),
-            raise_for_status=True,
-        ) as response:
-            payload = await response.json(content_type=None)
+    def _create_stream_client(self) -> NanoKVMClient | None:
+        """Create a NanoKVM client using the integration's resolved transport."""
+        config_entry = self.coordinator.config_entry
+        if not config_entry or not config_entry.data:
+            return None
 
-        code = payload.get("code") if isinstance(payload, dict) else None
-        token = payload.get("data", {}).get("token") if isinstance(payload, dict) else None
-        if code != 0 or not token:
-            msg = payload.get("msg", "unknown") if isinstance(payload, dict) else "unknown"
-            raise RuntimeError(f"Stream authentication failed: code={code}, msg={msg}")
-        return token
+        active_url = str(self.coordinator.client.url)
+        ssl_fingerprint = (
+            config_entry.data.get(CONF_SSL_FINGERPRINT)
+            if self.coordinator.client.url.scheme == "https"
+            else None
+        )
+        return NanoKVMClient(
+            active_url,
+            token=self.coordinator.client.token,
+            ssl_fingerprint=ssl_fingerprint,
+        )
+
+    async def _authenticate_stream_client(self, client: NanoKVMClient) -> None:
+        """Authenticate a stream client using the configured credentials."""
+        credentials = self._stream_credentials()
+        if credentials is None:
+            raise RuntimeError("Missing NanoKVM stream credentials")
+
+        if client.token:
+            return
+
+        username, password = credentials
+        await client.authenticate(username, password)
 
     async def _async_read_snapshot_frame(self) -> bytes | None:
         """Read one JPEG frame from NanoKVM MJPEG endpoint for snapshots."""
-        conn = self._stream_connection_info()
-        if conn is None:
+        client = self._create_stream_client()
+        if client is None:
             return None
 
-        base_url, username, password = conn
-        stream_url = f"{base_url}stream/mjpeg"
-
-        async with aiohttp.ClientSession() as session:
-            token = await self._authenticate_stream(session, base_url, username, password)
-            async with session.get(
-                stream_url,
-                cookies={"nano-kvm-token": token},
-                timeout=aiohttp.ClientTimeout(total=None, sock_read=None),
-                raise_for_status=True,
+        async with client:
+            await self._authenticate_stream_client(client)
+            # Reuse NanoKVMClient's authenticated session and SSL config for MJPEG.
+            async with client._request(
+                aiohttp.hdrs.METH_GET,
+                "/stream/mjpeg",
             ) as upstream:
                 reader = MultipartReader.from_response(upstream)
 

--- a/custom_components/nanokvm/camera_webrtc.py
+++ b/custom_components/nanokvm/camera_webrtc.py
@@ -19,6 +19,7 @@ from homeassistant.components.camera.webrtc import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from nanokvm.client import NanoKVMClient
 from webrtc_models import RTCIceCandidateInit
 from yarl import URL
 
@@ -26,7 +27,7 @@ from yarl import URL
 class _NanoKVMWebRTCSession:
     """Internal state for an active NanoKVM WebRTC signaling session."""
 
-    http_session: aiohttp.ClientSession
+    client: NanoKVMClient
     websocket: aiohttp.ClientWebSocketResponse
     reader_task: asyncio.Task[None] | None = None
 
@@ -38,6 +39,10 @@ class _WebSocketTimeoutKwargs(TypedDict, total=False):
     receive_timeout: float
 
 
+StreamClientFactory = Callable[[], NanoKVMClient | None]
+AuthenticateClientCallable = Callable[[NanoKVMClient], Awaitable[None]]
+
+
 class NanoKVMWebRTCManager:
     """Manage native Home Assistant WebRTC signaling for NanoKVM cameras."""
 
@@ -46,10 +51,8 @@ class NanoKVMWebRTCManager:
         *,
         logger: logging.Logger,
         hass_provider: Callable[[], HomeAssistant | None],
-        connection_info_provider: Callable[[], tuple[str, str, str] | None],
-        authenticate_stream: Callable[
-            [aiohttp.ClientSession, str, str, str], Awaitable[str]
-        ],
+        client_factory: StreamClientFactory,
+        authenticate_client: AuthenticateClientCallable,
         login_timeout_seconds: int = 15,
         websocket_heartbeat_seconds: float = 30.0,
         max_pending_ice_candidates: int = 64,
@@ -57,8 +60,8 @@ class NanoKVMWebRTCManager:
         """Initialize WebRTC manager."""
         self._logger = logger
         self._hass_provider = hass_provider
-        self._connection_info_provider = connection_info_provider
-        self._authenticate_stream = authenticate_stream
+        self._client_factory = client_factory
+        self._authenticate_client = authenticate_client
         self._login_timeout_seconds = login_timeout_seconds
         self._websocket_heartbeat_seconds = websocket_heartbeat_seconds
         self._max_pending_ice_candidates = max_pending_ice_candidates
@@ -66,11 +69,10 @@ class NanoKVMWebRTCManager:
         self._pending_candidates: dict[str, list[RTCIceCandidateInit]] = {}
         self._session_lock = asyncio.Lock()
 
-    def _webrtc_stream_url(self, base_url: str) -> str:
+    def _webrtc_stream_url(self, base_url: URL) -> str:
         """Build NanoKVM h264 WebRTC websocket URL from API base URL."""
-        api_url = URL(base_url)
-        ws_scheme = "wss" if api_url.scheme == "https" else "ws"
-        return str(api_url.with_scheme(ws_scheme) / "stream/h264")
+        ws_scheme = "wss" if base_url.scheme == "https" else "ws"
+        return str(base_url.with_scheme(ws_scheme) / "stream/h264")
 
     def _websocket_timeout_kwargs(self) -> _WebSocketTimeoutKwargs:
         """Return websocket timeout kwargs compatible with installed aiohttp."""
@@ -83,18 +85,14 @@ class NanoKVMWebRTCManager:
         self, offer_sdp: str, session_id: str, send_message: WebRTCSendMessage
     ) -> None:
         """Handle Home Assistant WebRTC offer using NanoKVM /stream/h264 signaling."""
-        conn = self._connection_info_provider()
-        if conn is None:
-            raise HomeAssistantError("Missing NanoKVM connection info")
+        client = self._client_factory()
+        if client is None:
+            raise HomeAssistantError("Missing NanoKVM WebRTC client")
 
         hass = self._hass_provider()
         if hass is None:
             raise HomeAssistantError("Home Assistant is not ready for WebRTC")
 
-        base_url, username, password = conn
-        ws_url = self._webrtc_stream_url(base_url)
-
-        http_session = aiohttp.ClientSession()
         registered = False
 
         # Frontend can send ICE candidates before signaling websocket is ready.
@@ -102,18 +100,26 @@ class NanoKVMWebRTCManager:
             self._pending_candidates.setdefault(session_id, [])
 
         try:
-            token = await self._authenticate_stream(
-                http_session, base_url, username, password
-            )
-            websocket = await http_session.ws_connect(
-                ws_url,
-                headers={"Cookie": f"nano-kvm-token={token}"},
+            await client.__aenter__()
+            await self._authenticate_client(client)
+
+            if client.token is None:
+                raise RuntimeError("NanoKVM client authentication did not produce a token")
+            if client._session is None or client._ssl_config is None:
+                raise RuntimeError("NanoKVM client transport is not initialized")
+
+            # The library does not expose WebRTC signaling yet, so reuse its
+            # configured session, URL, and SSL settings directly.
+            websocket = await client._session.ws_connect(
+                self._webrtc_stream_url(client.url),
+                headers={"Cookie": f"nano-kvm-token={client.token}"},
                 heartbeat=self._websocket_heartbeat_seconds,
+                ssl=client._ssl_config,
                 **self._websocket_timeout_kwargs(),
             )
 
             webrtc_session = _NanoKVMWebRTCSession(
-                http_session=http_session,
+                client=client,
                 websocket=websocket,
             )
             async with self._session_lock:
@@ -134,7 +140,7 @@ class NanoKVMWebRTCManager:
                 async with self._session_lock:
                     self._pending_candidates.pop(session_id, None)
                 with suppress(Exception):
-                    await http_session.close()
+                    await client.__aexit__(None, None, None)
             raise HomeAssistantError(
                 f"Unable to establish NanoKVM WebRTC signaling: {err}"
             ) from err
@@ -292,7 +298,7 @@ class NanoKVMWebRTCManager:
                 await session.websocket.close()
 
         with suppress(Exception):
-            await session.http_session.close()
+            await session.client.__aexit__(None, None, None)
 
     def close_webrtc_session(self, session_id: str) -> None:
         """Close a WebRTC session when frontend unsubscribes."""

--- a/custom_components/nanokvm/config_flow.py
+++ b/custom_components/nanokvm/config_flow.py
@@ -24,29 +24,47 @@ from .const import (
     DOMAIN,
     INTEGRATION_TITLE,
 )
-from .utils import normalize_host, normalize_mdns
+from .utils import api_connection_options, https_probe_url, normalize_host, normalize_mdns
 
 _LOGGER = logging.getLogger(__name__)
 
 async def validate_input(data: dict[str, Any]) -> str:
     """Validate the user input allows us to connect."""
-    async with NanoKVMClient(
-        normalize_host(data[CONF_HOST]),
-        ssl_fingerprint=data.get(CONF_SSL_FINGERPRINT),
-    ) as client:
-        try:
-            await client.authenticate(data[CONF_USERNAME], data[CONF_PASSWORD])
-            device_info = await client.get_info()
-        except NanoKVMAuthenticationFailure as err:
-            raise InvalidAuth from err
-        except (aiohttp.ClientConnectorCertificateError,
-                aiohttp.ServerFingerprintMismatch) as err:
-            raise SSLCertificateChanged from err
-        except (aiohttp.ClientConnectorError, asyncio.TimeoutError,
-                aiohttp.ClientError, NanoKVMError) as err:
-            raise CannotConnect from err
+    options = api_connection_options(
+        data[CONF_HOST],
+        data.get(CONF_SSL_FINGERPRINT),
+    )
+    last_error: Exception | None = None
 
-    return str(device_info.device_key)
+    for index, option in enumerate(options):
+        async with NanoKVMClient(
+            option.base_url,
+            ssl_fingerprint=option.ssl_fingerprint,
+        ) as client:
+            try:
+                await client.authenticate(data[CONF_USERNAME], data[CONF_PASSWORD])
+                device_info = await client.get_info()
+                return str(device_info.device_key)
+            except NanoKVMAuthenticationFailure as err:
+                raise InvalidAuth from err
+            except (
+                aiohttp.ClientConnectorCertificateError,
+                aiohttp.ServerFingerprintMismatch,
+            ) as err:
+                if option.scheme == "http" and index < len(options) - 1:
+                    last_error = err
+                    continue
+                raise SSLCertificateChanged from err
+            except aiohttp.ClientConnectorError as err:
+                last_error = err
+                if index < len(options) - 1:
+                    continue
+            except (asyncio.TimeoutError, aiohttp.ClientError, NanoKVMError) as err:
+                last_error = err
+                break
+
+    assert last_error is not None
+    raise CannotConnect from last_error
 
 
 class NanoKVMConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -158,7 +176,7 @@ class NanoKVMConfigFlow(ConfigFlow, domain=DOMAIN):
         """Fetch the remote fingerprint and redirect to the SSL confirmation step."""
         self._ssl_return_step = return_step
         self._discovered_fingerprint = await async_fetch_remote_fingerprint(
-            normalize_host(self.data[CONF_HOST])
+            https_probe_url(self.data[CONF_HOST])
         )
 
         if return_step == "reauth_finish" and self.data.get(CONF_SSL_FINGERPRINT):
@@ -284,7 +302,11 @@ class NanoKVMConfigFlow(ConfigFlow, domain=DOMAIN):
         except InvalidAuth:
             return await self.async_step_reauth_confirm()
         except (CannotConnect, SSLCertificateChanged, Exception) as err:
-            _LOGGER.error("Reauth failed after SSL confirmation: %s", err)
+            _LOGGER.error(
+                "Reauth failed after SSL confirmation: %s: %s",
+                type(err).__name__,
+                err,
+            )
             return self.async_abort(reason="cannot_connect")
 
         return await self._async_finish_reauth(entry, device_key)

--- a/custom_components/nanokvm/coordinator.py
+++ b/custom_components/nanokvm/coordinator.py
@@ -33,7 +33,7 @@ from .const import (
     SIGNAL_NEW_SSH_SENSORS,
 )
 from .ssh_metrics import SSHMetricsCollector
-from .utils import extract_ssh_host, normalize_host
+from .utils import api_connection_options, extract_ssh_host
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -140,11 +140,19 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         """Fetch data once, handling reauthentication when needed."""
         try:
             return await self._async_fetch_with_client()
-        except (aiohttp.ServerFingerprintMismatch,
-                aiohttp.ClientConnectorCertificateError) as err:
+        except (
+            aiohttp.ServerFingerprintMismatch,
+            aiohttp.ClientConnectorCertificateError,
+        ) as err:
+            if self.client.url.scheme == "http" and await self._async_failover_client(err):
+                return await self._async_fetch_with_client()
             raise ConfigEntryAuthFailed(
                 "SSL certificate changed for NanoKVM"
             ) from err
+        except aiohttp.ClientConnectorError as err:
+            if await self._async_failover_client(err):
+                return await self._async_fetch_with_client()
+            raise UpdateFailed(f"Error communicating with NanoKVM: {err}") from err
         except (aiohttp.ClientResponseError, NanoKVMAuthenticationFailure) as err:
             if _is_auth_failure(err):
                 await self._async_reauthenticate_client(err)
@@ -180,25 +188,103 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_reauthenticate_client(self, original_error: Exception) -> None:
         """Reauthenticate and replace the client when token/auth fails."""
-        host = normalize_host(self.config_entry.data[CONF_HOST])
-        ssl_fingerprint = self.config_entry.data.get(CONF_SSL_FINGERPRINT)
-        new_client = NanoKVMClient(host, ssl_fingerprint=ssl_fingerprint)
-        try:
-            async with new_client:
-                await new_client.authenticate(self.username, self.password)
-            self.client = new_client
-        except (aiohttp.ClientResponseError, NanoKVMAuthenticationFailure) as auth_err:
-            if _is_auth_failure(auth_err):
+        options = api_connection_options(
+            self.config_entry.data[CONF_HOST],
+            self.config_entry.data.get(CONF_SSL_FINGERPRINT),
+            preferred_url=str(self.client.url),
+        )
+        last_error: Exception | None = None
+
+        for index, option in enumerate(options):
+            new_client = NanoKVMClient(
+                option.base_url,
+                ssl_fingerprint=option.ssl_fingerprint,
+            )
+            try:
+                async with new_client:
+                    await new_client.authenticate(self.username, self.password)
+                self.client = new_client
+                return
+            except (aiohttp.ClientResponseError, NanoKVMAuthenticationFailure) as auth_err:
+                if _is_auth_failure(auth_err):
+                    raise ConfigEntryAuthFailed(
+                        "Stored NanoKVM credentials are no longer valid"
+                    ) from auth_err
+                if isinstance(auth_err, aiohttp.ClientResponseError):
+                    raise UpdateFailed(f"Reauthentication failed: {auth_err}") from auth_err
+                raise UpdateFailed(f"Authentication failed: {auth_err}") from auth_err
+            except (
+                aiohttp.ServerFingerprintMismatch,
+                aiohttp.ClientConnectorCertificateError,
+            ) as auth_err:
+                if option.scheme == "http" and index < len(options) - 1:
+                    last_error = auth_err
+                    continue
+                raise ConfigEntryAuthFailed(
+                    "SSL certificate changed for NanoKVM"
+                ) from auth_err
+            except aiohttp.ClientConnectorError as auth_err:
+                last_error = auth_err
+                continue
+            except (NanoKVMError, aiohttp.ClientError, asyncio.TimeoutError) as auth_err:
+                if isinstance(original_error, aiohttp.ClientResponseError):
+                    raise UpdateFailed(f"Reauthentication failed: {auth_err}") from auth_err
+                raise UpdateFailed(f"Authentication failed: {auth_err}") from auth_err
+
+        if isinstance(original_error, aiohttp.ClientResponseError):
+            assert last_error is not None
+            raise UpdateFailed(f"Reauthentication failed: {last_error}") from last_error
+        if last_error is not None:
+            raise UpdateFailed(f"Authentication failed: {last_error}") from last_error
+
+    async def _async_failover_client(self, original_error: Exception) -> bool:
+        """Switch to an alternate API transport after a connection failure."""
+        options = api_connection_options(
+            self.config_entry.data[CONF_HOST],
+            self.config_entry.data.get(CONF_SSL_FINGERPRINT),
+            preferred_url=str(self.client.url),
+        )
+        fallback_options = tuple(
+            option for option in options if option.base_url != str(self.client.url)
+        )
+
+        for option in fallback_options:
+            new_client = NanoKVMClient(
+                option.base_url,
+                ssl_fingerprint=option.ssl_fingerprint,
+            )
+            try:
+                async with new_client:
+                    await new_client.authenticate(self.username, self.password)
+                _LOGGER.debug(
+                    "Switched NanoKVM API transport from %s to %s after connection failure",
+                    self.client.url,
+                    option.base_url,
+                )
+                self.client = new_client
+                return True
+            except NanoKVMAuthenticationFailure as err:
                 raise ConfigEntryAuthFailed(
                     "Stored NanoKVM credentials are no longer valid"
-                ) from auth_err
-            if isinstance(auth_err, aiohttp.ClientResponseError):
-                raise UpdateFailed(f"Reauthentication failed: {auth_err}") from auth_err
-            raise UpdateFailed(f"Authentication failed: {auth_err}") from auth_err
-        except (NanoKVMError, aiohttp.ClientError, asyncio.TimeoutError) as auth_err:
-            if isinstance(original_error, aiohttp.ClientResponseError):
-                raise UpdateFailed(f"Reauthentication failed: {auth_err}") from auth_err
-            raise UpdateFailed(f"Authentication failed: {auth_err}") from auth_err
+                ) from err
+            except (
+                aiohttp.ServerFingerprintMismatch,
+                aiohttp.ClientConnectorCertificateError,
+            ) as err:
+                raise ConfigEntryAuthFailed(
+                    "SSL certificate changed for NanoKVM"
+                ) from err
+            except aiohttp.ClientConnectorError:
+                continue
+            except (NanoKVMError, aiohttp.ClientError, asyncio.TimeoutError) as err:
+                raise UpdateFailed(f"Error communicating with NanoKVM: {err}") from err
+
+        _LOGGER.debug(
+            "No alternate NanoKVM API transport succeeded after connection failure from %s: %s",
+            self.client.url,
+            original_error,
+        )
+        return False
 
     async def _async_fetch_core_data(self) -> None:
         """Fetch required API data used by entities."""

--- a/custom_components/nanokvm/services.py
+++ b/custom_components/nanokvm/services.py
@@ -32,7 +32,7 @@ from .const import (
     SERVICE_WAKE_ON_LAN,
 )
 from .coordinator import NanoKVMDataUpdateCoordinator
-from .utils import normalize_host
+from .utils import host_match_key
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -102,12 +102,12 @@ def async_register_services(hass: HomeAssistant) -> None:
                 "Multiple NanoKVM devices are configured; specify the host field to target one device"
             )
 
-        normalized_requested_host = normalize_host(requested_host)
+        requested_host_key = host_match_key(requested_host)
         matches = [
             coordinator
             for coordinator in coordinators
-            if normalize_host(coordinator.config_entry.data[CONF_HOST])
-            == normalized_requested_host
+            if host_match_key(coordinator.config_entry.data[CONF_HOST])
+            == requested_host_key
         ]
 
         if not matches:

--- a/custom_components/nanokvm/translations/fr.json
+++ b/custom_components/nanokvm/translations/fr.json
@@ -24,6 +24,14 @@
       "reauth_confirm": {
         "title": "Réauthentifier Sipeed NanoKVM",
         "description": "L'intégration NanoKVM a besoin d'identifiants mis à jour pour {name}."
+      },
+      "ssl_fingerprint": {
+        "title": "Vérifier le certificat SSL",
+        "description": "L'appareil NanoKVM à l'adresse **{host}** a présenté un certificat auto-signé avec l'empreinte SHA-256 suivante :\n\n`{fingerprint}`\n\nFaites-vous confiance à ce certificat ?"
+      },
+      "ssl_fingerprint_changed": {
+        "title": "Le certificat SSL a changé",
+        "description": "Le certificat SSL de l'appareil NanoKVM à l'adresse **{host}** a changé.\n\n**Empreinte précédente :**\n`{old_fingerprint}`\n\n**Nouvelle empreinte :**\n`{new_fingerprint}`\n\nCela peut signifier que l'appareil a généré un nouveau certificat, ou que quelque chose intercepte la connexion. Acceptez uniquement si vous vous attendez à ce changement."
       }
     },
     "abort": {
@@ -32,7 +40,8 @@
     "error": {
       "cannot_connect": "Échec de la connexion",
       "invalid_auth": "Authentification invalide",
-      "unknown": "Erreur inattendue"
+      "unknown": "Erreur inattendue",
+      "ssl_certificate_changed": "Le certificat SSL a changé"
     }
   },
   "entity": {

--- a/custom_components/nanokvm/translations/pt-BR.json
+++ b/custom_components/nanokvm/translations/pt-BR.json
@@ -24,6 +24,14 @@
       "reauth_confirm": {
         "title": "Reautenticar Sipeed NanoKVM",
         "description": "A integração NanoKVM precisa de credenciais atualizadas para {name}."
+      },
+      "ssl_fingerprint": {
+        "title": "Verificar certificado SSL",
+        "description": "O dispositivo NanoKVM em **{host}** apresentou um certificado autoassinado com a seguinte impressão digital SHA-256:\n\n`{fingerprint}`\n\nVocê confia neste certificado?"
+      },
+      "ssl_fingerprint_changed": {
+        "title": "Certificado SSL alterado",
+        "description": "O certificado SSL do dispositivo NanoKVM em **{host}** foi alterado.\n\n**Impressão digital anterior:**\n`{old_fingerprint}`\n\n**Nova impressão digital:**\n`{new_fingerprint}`\n\nIsso pode significar que o dispositivo gerou um novo certificado ou que algo está interceptando a conexão. Aceite apenas se você esperava essa mudança."
       }
     },
     "abort": {
@@ -32,7 +40,8 @@
     "error": {
       "cannot_connect": "Falha ao conectar",
       "invalid_auth": "Autenticação inválida",
-      "unknown": "Erro inesperado"
+      "unknown": "Erro inesperado",
+      "ssl_certificate_changed": "O certificado SSL foi alterado"
     }
   },
   "entity": {

--- a/custom_components/nanokvm/utils.py
+++ b/custom_components/nanokvm/utils.py
@@ -1,16 +1,131 @@
 """Shared utility helpers for the Sipeed NanoKVM integration."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 
-def normalize_host(host: str) -> str:
-    """Normalize a host value to an API base URL."""
-    if not host.startswith(("http://", "https://")):
-        host = f"http://{host}"
+from yarl import URL
 
-    if not host.endswith("/api/"):
-        host = f"{host}api/" if host.endswith("/") else f"{host}/api/"
 
+@dataclass(frozen=True, slots=True)
+class NanoKVMAPIConnectionOption:
+    """Resolved API base URL plus the applicable SSL fingerprint setting."""
+
+    base_url: str
+    scheme: str
+    ssl_fingerprint: str | None
+
+
+def _normalize_api_path(path: str) -> str:
+    """Normalize an origin path to the NanoKVM API base path."""
+    normalized_path = path.rstrip("/")
+    if not normalized_path:
+        return "/api/"
+    if normalized_path.endswith("/api"):
+        return f"{normalized_path}/"
+    return f"{normalized_path}/api/"
+
+
+def _parse_host(host: str) -> tuple[URL, bool]:
+    """Parse a configured host and return the origin plus scheme state."""
+    raw_host = host.strip()
+    has_explicit_scheme = "://" in raw_host
+    origin = URL(raw_host if has_explicit_scheme else f"http://{raw_host}")
+    return origin.with_query(None).with_fragment(None), has_explicit_scheme
+
+
+def _api_base_url(origin: URL, scheme: str) -> str:
+    """Build an API base URL from a parsed origin and target scheme."""
+    return str(origin.with_scheme(scheme).with_path(_normalize_api_path(origin.path)))
+
+
+def _ssh_host(origin: URL) -> str:
+    """Return the hostname to use for SSH connections."""
+    host = origin.host or origin.raw_host
+    if host is None:
+        raise ValueError(f"Invalid NanoKVM host value: {origin}")
     return host
+
+
+@dataclass(frozen=True, slots=True)
+class NanoKVMConnectionTarget:
+    """Parsed connection target derived from a configured host value."""
+
+    origin: URL
+    has_explicit_scheme: bool
+
+    @classmethod
+    def from_host(cls, host: str) -> NanoKVMConnectionTarget:
+        """Parse the stored host value into a reusable connection target."""
+        origin, has_explicit_scheme = _parse_host(host)
+        return cls(origin=origin, has_explicit_scheme=has_explicit_scheme)
+
+    @property
+    def ssh_host(self) -> str:
+        """Return the hostname to use for SSH connections."""
+        return _ssh_host(self.origin)
+
+    @property
+    def match_key(self) -> tuple[str, int | None, str]:
+        """Return a normalized key for matching configured devices."""
+        return self.ssh_host, self.origin.port, _normalize_api_path(self.origin.path)
+
+    def api_connection_options(
+        self,
+        ssl_fingerprint: str | None = None,
+        *,
+        preferred_url: str | None = None,
+    ) -> tuple[NanoKVMAPIConnectionOption, ...]:
+        """Return candidate API connection options for this target."""
+        schemes = (
+            (self.origin.scheme,) if self.has_explicit_scheme else ("http", "https")
+        )
+        options = [
+            NanoKVMAPIConnectionOption(
+                base_url=_api_base_url(self.origin, scheme),
+                scheme=scheme,
+                ssl_fingerprint=ssl_fingerprint if scheme == "https" else None,
+            )
+            for scheme in schemes
+        ]
+        if preferred_url is None:
+            return tuple(options)
+
+        preferred = [option for option in options if option.base_url == preferred_url]
+        if not preferred:
+            return tuple(options)
+
+        remaining = [option for option in options if option.base_url != preferred_url]
+        return tuple(preferred + remaining)
+
+    @property
+    def https_probe_url(self) -> str:
+        """Return the HTTPS API base URL for certificate fingerprint probing."""
+        return _api_base_url(self.origin, "https")
+
+
+def api_connection_options(
+    host: str,
+    ssl_fingerprint: str | None = None,
+    *,
+    preferred_url: str | None = None,
+) -> tuple[NanoKVMAPIConnectionOption, ...]:
+    """Return candidate API connection options for a configured host."""
+    return NanoKVMConnectionTarget.from_host(host).api_connection_options(
+        ssl_fingerprint=ssl_fingerprint,
+        preferred_url=preferred_url,
+    )
+
+
+def https_probe_url(host: str) -> str:
+    """Return the HTTPS API base URL for certificate fingerprint probing."""
+    return NanoKVMConnectionTarget.from_host(host).https_probe_url
+
+
+def normalize_host(host: str, ssl_fingerprint: str | None = None) -> str:
+    """Return the first candidate API base URL for a configured host."""
+    return NanoKVMConnectionTarget.from_host(host).api_connection_options(
+        ssl_fingerprint=ssl_fingerprint,
+    )[0].base_url
 
 
 def normalize_mdns(mdns: str) -> str:
@@ -20,4 +135,9 @@ def normalize_mdns(mdns: str) -> str:
 
 def extract_ssh_host(host: str) -> str:
     """Extract SSH host value from integration host configuration."""
-    return host.replace("/api/", "").replace("http://", "").replace("https://", "")
+    return NanoKVMConnectionTarget.from_host(host).ssh_host
+
+
+def host_match_key(host: str) -> tuple[str, int | None, str]:
+    """Return a normalized key for matching a host to a config entry."""
+    return NanoKVMConnectionTarget.from_host(host).match_key


### PR DESCRIPTION
## Summary

This PR cleans up NanoKVM transport handling so the integration behaves consistently across HTTP and HTTPS, including camera/WebRTC paths and host normalization.

## What Changed

- centralize host parsing and connection target resolution in `utils.py`
- replace brittle string-based URL/SSH parsing with a structured connection target
- support consistent API connection candidate resolution for:
  - explicit `http://...`
  - explicit `https://...`
  - bare hosts like `192.168.5.187`
- update integration setup and coordinator logic to use the shared connection resolver
- allow automatic transport failover when the device moves from HTTPS back to HTTP
- treat HTTP -> HTTPS transitions with self-signed certificates as certificate-change flows that require fingerprint confirmation
- move camera snapshot and WebRTC signaling to use `NanoKVMClient` transport behavior instead of standalone raw request handling
- align `fr` and `pt-BR` translations with the SSL fingerprint flow already present in `en`

## Why

Before this change, transport handling was split across multiple places and relied on string manipulation to derive API and SSH targets. That led to a few problems:

- camera and WebRTC did not follow the same SSL behavior as the rest of the integration
- switching between HTTP and HTTPS could leave the integration in a broken state
- trailing slashes / URL formatting created avoidable parsing bugs
- translation coverage for the SSL certificate flow was incomplete outside English

This PR makes transport selection and host normalization consistent across the integration.

## Behavior After This Change

- if the entry uses a bare host, the integration can adapt to the device running on HTTP or HTTPS
- if the device falls back from HTTPS to HTTP, the integration can switch automatically
- if the device moves from HTTP to HTTPS with a self-signed certificate, the user is prompted to confirm the new certificate fingerprint
- camera snapshot and WebRTC signaling follow the same resolved transport as the main API path
