### PR TITLE
fix: keep offline NanoKVM devices from blocking coordinator refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ Each platform follows a similar pattern:
   When the configured host has no scheme, the integration will try HTTP first
   and then HTTPS, supporting self-signed certificates via stored fingerprints.
 
-## Local CI/CD (Pre-Push)
+## Local Validation (Pre-Push)
 
 Run these checks locally before pushing:
 
@@ -133,10 +133,7 @@ Run these checks locally before pushing:
 2. Validate metadata JSON:
    - `Get-Content hacs.json | ConvertFrom-Json > $null`
    - `Get-Content custom_components/nanokvm/manifest.json | ConvertFrom-Json > $null`
-3. Local Home Assistant smoke test:
-   - `docker compose up -d --build`
-   - `docker compose logs --tail=200`
-   - `docker compose down`
+3. Verify the integration against a Home Assistant test instance and inspect logs.
 
 ## Required GitHub Workflows
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Recommended flow:
 Before opening a PR, run:
 
 1. `ruff check custom_components/nanokvm`
-2. Local Home Assistant smoke test (if relevant)
+2. Test the integration on a Home Assistant instance (if relevant)
 
 CI must pass on the PR branch:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ device settings, diagnostics, services, and camera streaming in Home Assistant.
 | Area | Capabilities |
 | --- | --- |
 | Power and hardware | Power/reset actions, status LEDs, HDMI output control (PCI-E) |
-| Device settings | SSH, mDNS, HID mode, OLED timeout, swap size, mouse jiggler |
+| Device settings | SSH, mDNS, HID mode, OLED timeout, swap size, mouse jiggler, watchdog |
 | Virtual devices | Virtual network and virtual disk switches |
 | Monitoring | Mounted image, CD-ROM mode, Tailscale, Wi-Fi |
 | Updates | Application version reporting and install action |
@@ -77,7 +77,7 @@ Notes:
 | Camera | HDMI stream camera with still snapshots and WebRTC |
 | Select | HID mode, Mouse Jiggler, OLED timeout, Swap size |
 | Sensor | Mounted image, Tailscale, SSH diagnostics |
-| Switch | Power, SSH, mDNS, Virtual network/disk, HDMI output |
+| Switch | Power, SSH, mDNS, Virtual network/disk, HDMI output, watchdog |
 | Update | Application version and install action |
 
 Notes:
@@ -86,6 +86,7 @@ Notes:
 - HDD LED is Alpha-only.
 - Wi-Fi entities only appear when the device reports Wi-Fi support.
 - SSH diagnostics appear after SSH is enabled on the NanoKVM.
+- The watchdog switch requires SSH and NanoKVM application version `2.2.2` or newer.
 
 ## Hardware Compatibility
 

--- a/custom_components/nanokvm/__init__.py
+++ b/custom_components/nanokvm/__init__.py
@@ -118,8 +118,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     domain_data = hass.data.get(DOMAIN, {})
     coordinator = domain_data.pop(entry.entry_id, None)
-    if coordinator and coordinator.ssh_metrics_collector:
-        await coordinator.ssh_metrics_collector.disconnect()
+    if coordinator:
+        await coordinator.async_shutdown()
 
     if not domain_data:
         async_unregister_services(hass)

--- a/custom_components/nanokvm/const.py
+++ b/custom_components/nanokvm/const.py
@@ -55,7 +55,9 @@ ICON_IMAGE = "mdi:disc"
 ICON_CDROM = "mdi:disc"
 ICON_MOUSE_JIGGLER = "mdi:mouse"
 ICON_HDMI = "mdi:video-input-hdmi"
+ICON_WATCHDOG = "mdi:shield-refresh"
 
 # Signals
 SIGNAL_NEW_SSH_SENSORS = "nanokvm_new_ssh_sensors_{}"
+SIGNAL_NEW_SSH_SWITCHES = "nanokvm_new_ssh_switches_{}"
 SIGNAL_NEW_MEDIA_ENTITIES = "nanokvm_new_media_entities_{}"

--- a/custom_components/nanokvm/coordinator.py
+++ b/custom_components/nanokvm/coordinator.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import aiohttp
 import async_timeout
+from awesomeversion import AwesomeVersion, AwesomeVersionException
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
@@ -31,6 +32,7 @@ from .const import (
     DOMAIN,
     SIGNAL_NEW_MEDIA_ENTITIES,
     SIGNAL_NEW_SSH_SENSORS,
+    SIGNAL_NEW_SSH_SWITCHES,
 )
 from .ssh_metrics import SSHMetricsCollector
 from .utils import api_connection_options, extract_ssh_host
@@ -40,6 +42,7 @@ _LOGGER = logging.getLogger(__name__)
 _UPDATE_MAX_ATTEMPTS = 3
 _UPDATE_RETRY_DELAY_SECONDS = 1
 _UPDATE_TIMEOUT_SECONDS = 10
+_WATCHDOG_MIN_VERSION = AwesomeVersion("2.2.2")
 
 
 def _is_auth_failure(error: Exception) -> bool:
@@ -90,8 +93,10 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         self.storage_used_percent = None
         self.media_entities_created = False
         self.ssh_sensors_created = False
+        self.ssh_switches_created = False
         self.ssh_metrics_collector = None
         self.hostname_info = None
+        self.watchdog_enabled = None
 
         super().__init__(
             hass,
@@ -353,16 +358,41 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
             "swap_size": self.swap_size,
             "tailscale_status": self.tailscale_status,
             "hostname_info": self.hostname_info,
+            "watchdog_enabled": self.watchdog_enabled,
         }
 
-    def _clear_ssh_metrics(self) -> None:
-        """Clear SSH-derived metrics from the coordinator."""
+    def _clear_ssh_runtime_state(self) -> None:
+        """Clear SSH-derived runtime state from the coordinator."""
         self.uptime = None
         self.cpu_temperature = None
         self.memory_total = None
         self.memory_used_percent = None
         self.storage_total = None
         self.storage_used_percent = None
+        self.watchdog_enabled = None
+
+    @property
+    def supports_watchdog(self) -> bool:
+        """Return whether NanoKVM watchdog support is available."""
+        application_version = self.device_info.application.strip()
+        if not application_version:
+            return False
+
+        try:
+            return AwesomeVersion(application_version) >= _WATCHDOG_MIN_VERSION
+        except AwesomeVersionException:
+            _LOGGER.debug(
+                "Unable to determine watchdog support from NanoKVM application version %r",
+                application_version,
+            )
+            return False
+
+    async def async_ensure_ssh_metrics_collector(self) -> SSHMetricsCollector:
+        """Return the active SSH collector, creating it when needed."""
+        if not self.ssh_metrics_collector:
+            host = extract_ssh_host(self.config_entry.data[CONF_HOST])
+            self.ssh_metrics_collector = SSHMetricsCollector(host=host, password=self.password)
+        return self.ssh_metrics_collector
 
     def _async_maybe_create_media_entities(self) -> None:
         """Signal when media-backed entities should be created."""
@@ -378,18 +408,16 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_ssh_data(self) -> None:
         """Fetch data via SSH."""
-        if not self.ssh_metrics_collector:
-            host = extract_ssh_host(self.config_entry.data[CONF_HOST])
-            self.ssh_metrics_collector = SSHMetricsCollector(host=host, password=self.password)
-
         try:
-            metrics = await self.ssh_metrics_collector.collect()
+            collector = await self.async_ensure_ssh_metrics_collector()
+            metrics = await collector.collect(include_watchdog=self.supports_watchdog)
             self.uptime = metrics.uptime
             self.cpu_temperature = metrics.cpu_temperature
             self.memory_total = metrics.memory_total
             self.memory_used_percent = metrics.memory_used_percent
             self.storage_total = metrics.storage_total
             self.storage_used_percent = metrics.storage_used_percent
+            self.watchdog_enabled = metrics.watchdog_enabled
             _LOGGER.debug(
                 "SSH coordinator metrics updated: uptime=%s cpu_temperature=%s memory_used_percent=%s storage_used_percent=%s",
                 self.uptime,
@@ -405,15 +433,22 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
                 )
                 self.ssh_sensors_created = True
 
+            if self.supports_watchdog and not self.ssh_switches_created:
+                _LOGGER.debug("Watchdog supported, signaling to create SSH-backed switches")
+                async_dispatcher_send(
+                    self.hass, SIGNAL_NEW_SSH_SWITCHES.format(self.config_entry.entry_id)
+                )
+                self.ssh_switches_created = True
+
         except Exception as err:
             _LOGGER.debug("Failed to fetch data via SSH: %s", err)
-            self._clear_ssh_metrics()
+            self._clear_ssh_runtime_state()
             if self.ssh_metrics_collector:
                 await self.ssh_metrics_collector.disconnect()
 
     async def _async_clear_ssh_data(self) -> None:
         """Clear SSH data and disconnect client."""
-        self._clear_ssh_metrics()
+        self._clear_ssh_runtime_state()
         if self.ssh_metrics_collector:
             await self.ssh_metrics_collector.disconnect()
             self.ssh_metrics_collector = None

--- a/custom_components/nanokvm/coordinator.py
+++ b/custom_components/nanokvm/coordinator.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import datetime
 import logging
 from typing import Any
@@ -23,7 +24,7 @@ from nanokvm.client import (
     NanoKVMClient,
     NanoKVMError,
 )
-from nanokvm.models import GetCdRomRsp, GetInfoRsp, GetMountedImageRsp, HidMode
+from nanokvm.models import GetCdRomRsp, GetInfoRsp, GetMountedImageRsp, GetVersionRsp, HidMode
 
 from .const import (
     CONF_SSL_FINGERPRINT,
@@ -42,6 +43,9 @@ _LOGGER = logging.getLogger(__name__)
 _UPDATE_MAX_ATTEMPTS = 3
 _UPDATE_RETRY_DELAY_SECONDS = 1
 _UPDATE_TIMEOUT_SECONDS = 10
+_APP_VERSION_REQUEST_TIMEOUT_SECONDS = 45
+_APP_VERSION_CACHE_SECONDS = 300
+_APP_VERSION_FAILURE_CACHE_SECONDS = 60
 _WATCHDOG_MIN_VERSION = AwesomeVersion("2.2.2")
 
 
@@ -97,6 +101,8 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         self.ssh_metrics_collector = None
         self.hostname_info = None
         self.watchdog_enabled = None
+        self._app_version_last_fetched: datetime.datetime | None = None
+        self._app_version_fetch_task: asyncio.Task[None] | None = None
 
         super().__init__(
             hass,
@@ -189,6 +195,7 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
             await self._async_fetch_storage_data()
             self._async_maybe_create_media_entities()
             await self._async_refresh_ssh_data()
+            self._async_schedule_app_version_refresh()
             return self._build_update_data()
 
     async def _async_reauthenticate_client(self, original_error: Exception) -> None:
@@ -303,11 +310,64 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         self.hid_mode = await self.client.get_hid_mode()
         self.oled_info = await self.client.get_oled_info()
         self.wifi_status = await self.client.get_wifi_status()
-        self.application_version_info = await self.client.get_application_version()
         self.hdmi_state = await self.client.get_hdmi_state()
         self.mouse_jiggler_state = await self.client.get_mouse_jiggler_state()
         self.swap_size = await self.client.get_swap_size()
         self.tailscale_status = await self.client.get_tailscale_status()
+
+    def _async_schedule_app_version_refresh(self) -> None:
+        """Refresh application version info outside the critical poll path."""
+        if (
+            self._app_version_fetch_task is not None
+            and not self._app_version_fetch_task.done()
+        ):
+            return
+
+        now = datetime.datetime.now(datetime.UTC)
+        cache_ttl = (
+            _APP_VERSION_CACHE_SECONDS
+            if self.application_version_info is not None
+            else _APP_VERSION_FAILURE_CACHE_SECONDS
+        )
+        if (
+            self._app_version_last_fetched is not None
+            and (now - self._app_version_last_fetched).total_seconds() < cache_ttl
+        ):
+            return
+
+        self._app_version_fetch_task = self.hass.async_create_task(
+            self._async_refresh_app_version()
+        )
+
+    async def _async_refresh_app_version(self) -> None:
+        """Fetch and cache application version info without blocking coordinator refreshes."""
+        try:
+            self.application_version_info = await self._async_fetch_app_version()
+            self._app_version_last_fetched = datetime.datetime.now(datetime.UTC)
+            self.async_update_listeners()
+        except asyncio.CancelledError:
+            raise
+        finally:
+            self._app_version_fetch_task = None
+
+    async def _async_fetch_app_version(self) -> GetVersionRsp | None:
+        """Fetch application version using a dedicated client and timeout."""
+        version_client = NanoKVMClient(
+            str(self.client.url),
+            token=self.client.token,
+            ssl_fingerprint=self.config_entry.data.get(CONF_SSL_FINGERPRINT),
+            request_timeout=_APP_VERSION_REQUEST_TIMEOUT_SECONDS,
+        )
+        try:
+            async with version_client:
+                return await version_client.get_application_version()
+        except (NanoKVMError, aiohttp.ClientError, asyncio.TimeoutError) as err:
+            _LOGGER.debug(
+                "Failed to fetch application version from NanoKVM: %s "
+                "(device may have no internet access)",
+                err,
+            )
+            return None
 
     async def _async_fetch_storage_data(self) -> None:
         """Fetch storage-specific state (mounted image and CD-ROM mode)."""
@@ -449,6 +509,18 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_clear_ssh_data(self) -> None:
         """Clear SSH data and disconnect client."""
         self._clear_ssh_runtime_state()
+        if self.ssh_metrics_collector:
+            await self.ssh_metrics_collector.disconnect()
+            self.ssh_metrics_collector = None
+
+    async def async_shutdown(self) -> None:
+        """Release any background tasks and live connections owned by the coordinator."""
+        if self._app_version_fetch_task is not None:
+            self._app_version_fetch_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._app_version_fetch_task
+            self._app_version_fetch_task = None
+
         if self.ssh_metrics_collector:
             await self.ssh_metrics_collector.disconnect()
             self.ssh_metrics_collector = None

--- a/custom_components/nanokvm/ssh_metrics.py
+++ b/custom_components/nanokvm/ssh_metrics.py
@@ -19,6 +19,7 @@ class SSHMetricsSnapshot:
     memory_used_percent: float | None
     storage_total: float | None
     storage_used_percent: float | None
+    watchdog_enabled: bool | None
 
 
 class SSHMetricsCollector:
@@ -34,18 +35,25 @@ class SSHMetricsCollector:
         if self._client.ssh_client:
             await self._client.disconnect()
 
-    async def collect(self) -> SSHMetricsSnapshot:
-        """Collect uptime, memory and storage stats."""
+    async def _async_ensure_connected(self) -> None:
+        """Connect the SSH client when needed."""
         ssh_client = self._client.ssh_client
         transport = ssh_client.get_transport() if ssh_client is not None else None
 
         if ssh_client is None or transport is None or not transport.is_active():
             await self._client.authenticate(self._password)
 
+    async def collect(self, *, include_watchdog: bool = False) -> SSHMetricsSnapshot:
+        """Collect uptime, memory, storage, and optional watchdog state."""
+        await self._async_ensure_connected()
+
         uptime = await self._fetch_uptime()
         cpu_temperature = await self._fetch_cpu_temperature()
         memory_stats = await self._fetch_memory()
         storage_stats = await self._fetch_storage()
+        watchdog_enabled = None
+        if include_watchdog:
+            watchdog_enabled = await self.fetch_watchdog_enabled()
 
         return SSHMetricsSnapshot(
             uptime=uptime,
@@ -54,7 +62,20 @@ class SSHMetricsCollector:
             memory_used_percent=memory_stats.get("used_percent"),
             storage_total=storage_stats.get("total"),
             storage_used_percent=storage_stats.get("used_percent"),
+            watchdog_enabled=watchdog_enabled,
         )
+
+    async def fetch_watchdog_enabled(self) -> bool:
+        """Return whether the NanoKVM watchdog file exists."""
+        await self._async_ensure_connected()
+        output = await self._client.run_command("test -f /etc/kvm/watchdog && echo 1 || echo 0")
+        return output.strip() == "1"
+
+    async def set_watchdog_enabled(self, enabled: bool) -> None:
+        """Enable or disable the NanoKVM watchdog file."""
+        await self._async_ensure_connected()
+        command = "touch /etc/kvm/watchdog" if enabled else "rm -f /etc/kvm/watchdog"
+        await self._client.run_command(command)
 
     async def _fetch_uptime(self) -> datetime.datetime | None:
         """Fetch uptime via SSH."""

--- a/custom_components/nanokvm/switch.py
+++ b/custom_components/nanokvm/switch.py
@@ -10,7 +10,8 @@ from typing import Any
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from nanokvm.models import GpioType, HWVersion, VirtualDevice
@@ -23,6 +24,8 @@ from .const import (
     ICON_NETWORK,
     ICON_SSH,
     ICON_POWER,
+    ICON_WATCHDOG,
+    SIGNAL_NEW_SSH_SWITCHES,
 )
 from .coordinator import NanoKVMDataUpdateCoordinator
 from .entity import NanoKVMEntity
@@ -55,6 +58,16 @@ def _hdmi_available(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
         and coordinator.hardware_info is not None
         and coordinator.hardware_info.version == HWVersion.PCIE
     )
+
+
+def _watchdog_value(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
+    """Return watchdog switch state."""
+    return bool(coordinator.watchdog_enabled)
+
+
+def _watchdog_available(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
+    """Return whether the watchdog switch should be available."""
+    return coordinator.supports_watchdog and coordinator.watchdog_enabled is not None
 
 
 SWITCHES: tuple[NanoKVMSwitchEntityDescription, ...] = (
@@ -128,6 +141,18 @@ SWITCHES: tuple[NanoKVMSwitchEntityDescription, ...] = (
     ),
 )
 
+SSH_SWITCHES: tuple[NanoKVMSwitchEntityDescription, ...] = (
+    NanoKVMSwitchEntityDescription(
+        key="watchdog",
+        name="Watchdog",
+        translation_key="watchdog",
+        icon=ICON_WATCHDOG,
+        entity_category=EntityCategory.CONFIG,
+        value_fn=_watchdog_value,
+        available_fn=_watchdog_available,
+    ),
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -169,6 +194,41 @@ async def async_setup_entry(
 
     async_add_entities(entities)
 
+    ssh_entities_added = False
+
+    @callback
+    def async_add_ssh_switches() -> None:
+        """Add SSH-backed switches when they become available."""
+        nonlocal ssh_entities_added
+        if ssh_entities_added:
+            return
+
+        entities = [
+            NanoKVMWatchdogSwitch(
+                coordinator=coordinator,
+                description=description,
+            )
+            for description in SSH_SWITCHES
+            if description.available_fn(coordinator)
+        ]
+        if not entities:
+            return
+
+        async_add_entities(entities)
+        ssh_entities_added = True
+        coordinator.ssh_switches_created = True
+
+    if any(description.available_fn(coordinator) for description in SSH_SWITCHES):
+        async_add_ssh_switches()
+
+    entry.async_on_unload(
+        async_dispatcher_connect(
+            hass,
+            SIGNAL_NEW_SSH_SWITCHES.format(entry.entry_id),
+            async_add_ssh_switches,
+        )
+    )
+
 
 class NanoKVMSwitch(NanoKVMEntity, SwitchEntity):
     """Defines a NanoKVM switch."""
@@ -191,6 +251,11 @@ class NanoKVMSwitch(NanoKVMEntity, SwitchEntity):
     def is_on(self) -> bool:
         """Return the state of the switch."""
         return self.entity_description.value_fn(self.coordinator)
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self.entity_description.available_fn(self.coordinator)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
@@ -271,3 +336,23 @@ class NanoKVMVirtualDeviceSwitch(NanoKVMSwitch):
         """Turn off the virtual device switch."""
         del kwargs
         await self._async_set_virtual_device_state(False)
+
+
+class NanoKVMWatchdogSwitch(NanoKVMSwitch):
+    """Defines a NanoKVM watchdog switch backed by SSH file control."""
+
+    async def _async_set_watchdog_state(self, enabled: bool) -> None:
+        """Set watchdog state via SSH and refresh coordinator state."""
+        collector = await self.coordinator.async_ensure_ssh_metrics_collector()
+        await collector.set_watchdog_enabled(enabled)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable the watchdog."""
+        del kwargs
+        await self._async_set_watchdog_state(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable the watchdog."""
+        del kwargs
+        await self._async_set_watchdog_state(False)

--- a/custom_components/nanokvm/translations/en.json
+++ b/custom_components/nanokvm/translations/en.json
@@ -158,6 +158,9 @@
       },
       "hdmi": {
         "name": "HDMI Output"
+      },
+      "watchdog": {
+        "name": "Watchdog"
       }
     },
     "select": {

--- a/custom_components/nanokvm/translations/fr.json
+++ b/custom_components/nanokvm/translations/fr.json
@@ -158,6 +158,9 @@
       },
       "hdmi": {
         "name": "Sortie HDMI"
+      },
+      "watchdog": {
+        "name": "Watchdog"
       }
     },
     "select": {

--- a/custom_components/nanokvm/translations/pt-BR.json
+++ b/custom_components/nanokvm/translations/pt-BR.json
@@ -158,6 +158,9 @@
       },
       "hdmi": {
         "name": "Saída HDMI"
+      },
+      "watchdog": {
+        "name": "Watchdog"
       }
     },
     "select": {


### PR DESCRIPTION
## Summary

This PR fixes issue #69 by decoupling the NanoKVM application-version lookup from the coordinator's critical polling path.

Previously, `get_application_version()` ran inside the main coordinator refresh under the same request path as the rest of the device state. On NanoKVM devices without internet access, that endpoint could block long enough to make initial setup or periodic refresh fail even though the device itself was otherwise reachable.

## What Changed

- removed application-version fetching from the required core-data refresh path
- added a dedicated background application-version fetch using a separate `NanoKVMClient`
- used a longer request timeout only for the application-version call
- added success and failure cache TTLs so the integration does not retry the slow version lookup on every poll cycle
- kept application-version fetch failures non-fatal and debug-only
- added coordinator shutdown cleanup for the background version-fetch task

## Behavior

- the main NanoKVM coordinator refresh keeps using the existing fast timeout
- normal entities continue to work even when the NanoKVM cannot reach the internet
- only the update entity becomes unavailable when application-version data cannot be fetched
- successful application-version results are cached for 5 minutes
- failed application-version fetches are retried after 60 seconds

Refs #69
