### PR TITLE
feat: add device visit link and IP sensor

### DIFF
--- a/custom_components/nanokvm/entity.py
+++ b/custom_components/nanokvm/entity.py
@@ -8,6 +8,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, INTEGRATION_TITLE
 from .coordinator import NanoKVMDataUpdateCoordinator
+from .utils import api_base_url_to_web_url
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,4 +60,5 @@ class NanoKVMEntity(CoordinatorEntity[NanoKVMDataUpdateCoordinator]):
             "model": f"{INTEGRATION_TITLE} {hw_version}",
             "sw_version": sw_version,
             "hw_version": hw_version,
+            "configuration_url": api_base_url_to_web_url(str(self.coordinator.client.url)),
         }

--- a/custom_components/nanokvm/sensor.py
+++ b/custom_components/nanokvm/sensor.py
@@ -56,6 +56,34 @@ def _mounted_image_value(coordinator: NanoKVMDataUpdateCoordinator) -> str:
     return coordinator.mounted_image.file if coordinator.mounted_image else ""
 
 
+def _primary_ip_address(coordinator: NanoKVMDataUpdateCoordinator) -> str | None:
+    """Return the preferred local IP address for the NanoKVM."""
+    addresses = coordinator.device_info.ips
+    if not addresses:
+        return None
+
+    for address in addresses:
+        if address.version == "IPv4":
+            return address.addr
+
+    return addresses[0].addr
+
+
+def _ip_address_attributes(coordinator: NanoKVMDataUpdateCoordinator) -> dict[str, Any]:
+    """Return all NanoKVM-reported addresses as sensor attributes."""
+    return {
+        "addresses": [
+            {
+                "name": address.name,
+                "addr": address.addr,
+                "version": address.version,
+                "type": address.type,
+            }
+            for address in coordinator.device_info.ips
+        ]
+    }
+
+
 def _tailscale_state_value(coordinator: NanoKVMDataUpdateCoordinator) -> str | None:
     """Return normalized tailscale state value."""
     if coordinator.tailscale_status is None:
@@ -109,6 +137,16 @@ MEDIA_SENSORS: tuple[NanoKVMSensorEntityDescription, ...] = (
 )
 
 SENSORS: tuple[NanoKVMSensorEntityDescription, ...] = (
+    NanoKVMSensorEntityDescription(
+        key="ip_address",
+        name="IP Address",
+        translation_key="ip_address",
+        icon=ICON_NETWORK,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_primary_ip_address,
+        available_fn=lambda coordinator: _primary_ip_address(coordinator) is not None,
+        attributes_fn=_ip_address_attributes,
+    ),
     NanoKVMSensorEntityDescription(
         key="tailscale_state",
         name="Tailscale",

--- a/custom_components/nanokvm/translations/en.json
+++ b/custom_components/nanokvm/translations/en.json
@@ -93,6 +93,14 @@
       "application_version": {
         "name": "Application Version"
       },
+      "ip_address": {
+        "name": "IP Address",
+        "state_attributes": {
+          "addresses": {
+            "name": "Addresses"
+          }
+        }
+      },
       "mounted_image": {
         "name": "Mounted Image"
       },

--- a/custom_components/nanokvm/translations/fr.json
+++ b/custom_components/nanokvm/translations/fr.json
@@ -93,6 +93,14 @@
       "application_version": {
         "name": "Version de l'application"
       },
+      "ip_address": {
+        "name": "Adresse IP",
+        "state_attributes": {
+          "addresses": {
+            "name": "Adresses"
+          }
+        }
+      },
       "mounted_image": {
         "name": "Image montée"
       },

--- a/custom_components/nanokvm/translations/pt-BR.json
+++ b/custom_components/nanokvm/translations/pt-BR.json
@@ -93,6 +93,14 @@
       "application_version": {
         "name": "Versão do Aplicativo"
       },
+      "ip_address": {
+        "name": "Endereço IP",
+        "state_attributes": {
+          "addresses": {
+            "name": "Endereços"
+          }
+        }
+      },
       "mounted_image": {
         "name": "Imagem Montada"
       },

--- a/custom_components/nanokvm/utils.py
+++ b/custom_components/nanokvm/utils.py
@@ -38,6 +38,14 @@ def _api_base_url(origin: URL, scheme: str) -> str:
     return str(origin.with_scheme(scheme).with_path(_normalize_api_path(origin.path)))
 
 
+def _web_ui_path(path: str) -> str:
+    """Convert an API base path into the corresponding web UI path."""
+    normalized_path = path.rstrip("/")
+    if normalized_path.endswith("/api"):
+        normalized_path = normalized_path[:-4]
+    return f"{normalized_path}/" if normalized_path else "/"
+
+
 def _ssh_host(origin: URL) -> str:
     """Return the hostname to use for SSH connections."""
     host = origin.host or origin.raw_host
@@ -119,6 +127,12 @@ def api_connection_options(
 def https_probe_url(host: str) -> str:
     """Return the HTTPS API base URL for certificate fingerprint probing."""
     return NanoKVMConnectionTarget.from_host(host).https_probe_url
+
+
+def api_base_url_to_web_url(base_url: str) -> str:
+    """Convert a NanoKVM API base URL into the corresponding web UI URL."""
+    parsed_url = URL(base_url).with_query(None).with_fragment(None)
+    return str(parsed_url.with_path(_web_ui_path(parsed_url.path)))
 
 
 def normalize_host(host: str, ssl_fingerprint: str | None = None) -> str:


### PR DESCRIPTION
## Summary

This PR improves the NanoKVM device page in Home Assistant by adding a Visit action and exposing the device IP address as a diagnostic sensor.

## What Changed

- add a diagnostic `ip_address` sensor based on the NanoKVM-reported network addresses
- expose all reported addresses, including IPv6 entries, as sensor attributes
- add a device `configuration_url` so Home Assistant shows a Visit button on the NanoKVM device page
- derive the Visit URL from the active NanoKVM base URL while preserving scheme, port, and reverse-proxy path prefixes

## Behavior

- the IP sensor state uses the first IPv4 address reported by the NanoKVM
- if no IPv4 address is reported, the sensor falls back to the first available address
- if no addresses are reported, the sensor is unavailable
- the sensor attributes include the full reported address list
- the device Visit button opens the NanoKVM web UI root instead of the API path
- HTTPS, non-default ports, and reverse-proxy prefixes are preserved in the Visit URL
