### PR TITLE
Feat/nanokvm pro support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,23 @@ Notes:
 | HDMI switch/button controls | PCI-E models |
 | HDD LED binary sensor | Alpha models |
 | SSH diagnostic sensors | Any model with SSH enabled |
+| Swap size, CD-ROM mode, virtual network/disk switches | Non-Pro models |
+
+### NanoKVM Pro
+
+NanoKVM Pro devices are supported. Because the Pro firmware no longer
+exposes the `/vm/swap`, `/vm/hdmi`, and `/storage/cdrom` endpoints and
+uses a different schema on `/vm/device/virtual`, the following entities
+are hidden on Pro:
+
+- Swap size select
+- HDMI output switch and Reset HDMI button
+- CD-ROM Mode binary sensor
+- Virtual Network and Virtual Disk switches
+
+All other entities work. See
+[`docs/plans/2026-04-14-nanokvm-pro-followups.md`](docs/plans/2026-04-14-nanokvm-pro-followups.md)
+for planned Pro-specific additions.
 
 ## Services
 

--- a/README.md
+++ b/README.md
@@ -109,9 +109,8 @@ are hidden on Pro:
 - CD-ROM Mode binary sensor
 - Virtual Network and Virtual Disk switches
 
-All other entities work. See
-[`docs/plans/2026-04-14-nanokvm-pro-followups.md`](docs/plans/2026-04-14-nanokvm-pro-followups.md)
-for planned Pro-specific additions.
+All other entities work. Planned Pro-specific additions will be documented
+in a future update.
 
 ## Services
 

--- a/custom_components/nanokvm/binary_sensor.py
+++ b/custom_components/nanokvm/binary_sensor.py
@@ -63,7 +63,7 @@ def _has_mounted_image(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
 
 def _cdrom_supported(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
     """Return whether the dedicated /storage/cdrom endpoint exists on this device."""
-    return coordinator.cdrom_status is not None
+    return coordinator.supports_cdrom_endpoint
 
 
 MEDIA_BINARY_SENSORS: tuple[NanoKVMBinarySensorEntityDescription, ...] = (

--- a/custom_components/nanokvm/binary_sensor.py
+++ b/custom_components/nanokvm/binary_sensor.py
@@ -61,6 +61,11 @@ def _has_mounted_image(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
     return bool(coordinator.mounted_image and coordinator.mounted_image.file != "")
 
 
+def _cdrom_supported(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
+    """Return whether the dedicated /storage/cdrom endpoint exists on this device."""
+    return coordinator.cdrom_status is not None
+
+
 MEDIA_BINARY_SENSORS: tuple[NanoKVMBinarySensorEntityDescription, ...] = (
     NanoKVMBinarySensorEntityDescription(
         key="cdrom_mode",
@@ -71,7 +76,9 @@ MEDIA_BINARY_SENSORS: tuple[NanoKVMBinarySensorEntityDescription, ...] = (
         value_fn=lambda coordinator: bool(
             coordinator.cdrom_status and coordinator.cdrom_status.cdrom == 1
         ),
-        available_fn=_has_mounted_image,
+        available_fn=lambda coordinator: _has_mounted_image(coordinator)
+        and _cdrom_supported(coordinator),
+        should_create_fn=_cdrom_supported,
     ),
 )
 
@@ -148,6 +155,7 @@ async def async_setup_entry(
                 description=description,
             )
             for description in MEDIA_BINARY_SENSORS
+            if description.should_create_fn(coordinator)
         )
         media_entities_added = True
 

--- a/custom_components/nanokvm/coordinator.py
+++ b/custom_components/nanokvm/coordinator.py
@@ -23,9 +23,15 @@ from nanokvm.client import (
     NanoKVMAuthenticationFailure,
     NanoKVMClient,
     NanoKVMError,
-    NanoKVMInvalidResponseError,
 )
-from nanokvm.models import GetCdRomRsp, GetInfoRsp, GetMountedImageRsp, GetVersionRsp, HidMode
+from nanokvm.models import (
+    GetCdRomRsp,
+    GetInfoRsp,
+    GetMountedImageRsp,
+    GetVersionRsp,
+    HidMode,
+    HWVersion,
+)
 
 from .const import (
     CONF_SSL_FINGERPRINT,
@@ -104,7 +110,6 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         self.watchdog_enabled = None
         self._app_version_last_fetched: datetime.datetime | None = None
         self._app_version_fetch_task: asyncio.Task[None] | None = None
-        self._unsupported_endpoints: set[str] = set()
 
         super().__init__(
             hass,
@@ -300,35 +305,14 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         )
         return False
 
-    def _mark_endpoint_unsupported(self, endpoint: str, err: Exception) -> None:
-        """Record that an endpoint is unsupported on this device and log once."""
-        if endpoint in self._unsupported_endpoints:
-            return
-        self._unsupported_endpoints.add(endpoint)
-        _LOGGER.info(
-            "NanoKVM endpoint %s unsupported on this device; skipping future calls (%s)",
-            endpoint,
-            err,
-        )
-
     async def _fetch_optional(self, endpoint: str, call):
-        """Run an optional endpoint call; return None when the device lacks it.
-
-        Catches only 404 responses and schema parse failures so that transient
-        5xx/timeout errors still surface and trigger retries. Once an endpoint
-        is recorded unsupported it is never called again for this coordinator.
-        """
-        if endpoint in self._unsupported_endpoints:
-            return None
+        """Run an optional endpoint call; return None when the device lacks it."""
         try:
             return await call()
         except aiohttp.ClientResponseError as err:
             if err.status != 404:
                 raise
-            self._mark_endpoint_unsupported(endpoint, err)
-            return None
-        except NanoKVMInvalidResponseError as err:
-            self._mark_endpoint_unsupported(endpoint, err)
+            _LOGGER.debug("NanoKVM endpoint %s is not available on this device", endpoint)
             return None
 
     async def _async_fetch_core_data(self) -> None:
@@ -337,21 +321,30 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         self.hostname_info = await self.client.get_hostname()
         self.hardware_info = await self.client.get_hardware()
         self.gpio_info = await self.client.get_gpio()
-        self.virtual_device_info = await self._fetch_optional(
-            "/vm/device/virtual", self.client.get_virtual_device_status
-        )
+        if self.supports_legacy_virtual_device_controls:
+            self.virtual_device_info = await self._fetch_optional(
+                "/vm/device/virtual", self.client.get_virtual_device_status
+            )
+        else:
+            self.virtual_device_info = None
         self.ssh_state = await self.client.get_ssh_state()
         self.mdns_state = await self.client.get_mdns_state()
         self.hid_mode = await self.client.get_hid_mode()
         self.oled_info = await self.client.get_oled_info()
         self.wifi_status = await self.client.get_wifi_status()
-        self.hdmi_state = await self._fetch_optional(
-            "/vm/hdmi", self.client.get_hdmi_state
-        )
+        if self.supports_hdmi_endpoint:
+            self.hdmi_state = await self._fetch_optional(
+                "/vm/hdmi", self.client.get_hdmi_state
+            )
+        else:
+            self.hdmi_state = None
         self.mouse_jiggler_state = await self.client.get_mouse_jiggler_state()
-        self.swap_size = await self._fetch_optional(
-            "/vm/swap", self.client.get_swap_size
-        )
+        if self.supports_swap_size:
+            self.swap_size = await self._fetch_optional(
+                "/vm/swap", self.client.get_swap_size
+            )
+        else:
+            self.swap_size = None
         self.tailscale_status = await self.client.get_tailscale_status()
 
     def _async_schedule_app_version_refresh(self) -> None:
@@ -419,18 +412,23 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
                 )
                 self.mounted_image = GetMountedImageRsp(file="")
 
-            try:
-                self.cdrom_status = await self._fetch_optional(
-                    "/storage/cdrom", self.client.get_cdrom_status
-                )
-            except NanoKVMApiError as err:
-                _LOGGER.debug(
-                    "Failed to get CD-ROM status, retrieving default value: %s", err
-                )
-                self.cdrom_status = GetCdRomRsp(cdrom=0)
+            if self.supports_cdrom_endpoint:
+                try:
+                    self.cdrom_status = await self._fetch_optional(
+                        "/storage/cdrom", self.client.get_cdrom_status
+                    )
+                except NanoKVMApiError as err:
+                    _LOGGER.debug(
+                        "Failed to get CD-ROM status, retrieving default value: %s", err
+                    )
+                    self.cdrom_status = GetCdRomRsp(cdrom=0)
+            else:
+                self.cdrom_status = None
         else:
             self.mounted_image = GetMountedImageRsp(file="")
-            self.cdrom_status = GetCdRomRsp(cdrom=0)
+            self.cdrom_status = (
+                GetCdRomRsp(cdrom=0) if self.supports_cdrom_endpoint else None
+            )
 
     async def _async_refresh_ssh_data(self) -> None:
         """Fetch or clear SSH metrics depending on SSH state."""
@@ -487,6 +485,35 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
                 application_version,
             )
             return False
+
+    @property
+    def is_pro_hardware(self) -> bool:
+        """Return whether the detected NanoKVM hardware is the Pro model."""
+        return bool(
+            self.hardware_info and self.hardware_info.version == HWVersion.PRO
+        )
+
+    @property
+    def supports_legacy_virtual_device_controls(self) -> bool:
+        """Return whether legacy virtual network/disk controls apply."""
+        return self.hardware_info is not None and not self.is_pro_hardware
+
+    @property
+    def supports_hdmi_endpoint(self) -> bool:
+        """Return whether the legacy HDMI endpoint should be queried."""
+        return bool(
+            self.hardware_info and self.hardware_info.version == HWVersion.PCIE
+        )
+
+    @property
+    def supports_swap_size(self) -> bool:
+        """Return whether the legacy swap-size endpoint should be queried."""
+        return self.hardware_info is not None and not self.is_pro_hardware
+
+    @property
+    def supports_cdrom_endpoint(self) -> bool:
+        """Return whether the legacy CD-ROM endpoint should be queried."""
+        return self.hardware_info is not None and not self.is_pro_hardware
 
     async def async_ensure_ssh_metrics_collector(self) -> SSHMetricsCollector:
         """Return the active SSH collector, creating it when needed."""

--- a/custom_components/nanokvm/coordinator.py
+++ b/custom_components/nanokvm/coordinator.py
@@ -23,6 +23,7 @@ from nanokvm.client import (
     NanoKVMAuthenticationFailure,
     NanoKVMClient,
     NanoKVMError,
+    NanoKVMInvalidResponseError,
 )
 from nanokvm.models import GetCdRomRsp, GetInfoRsp, GetMountedImageRsp, GetVersionRsp, HidMode
 
@@ -103,6 +104,7 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         self.watchdog_enabled = None
         self._app_version_last_fetched: datetime.datetime | None = None
         self._app_version_fetch_task: asyncio.Task[None] | None = None
+        self._unsupported_endpoints: set[str] = set()
 
         super().__init__(
             hass,
@@ -298,21 +300,58 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         )
         return False
 
+    def _mark_endpoint_unsupported(self, endpoint: str, err: Exception) -> None:
+        """Record that an endpoint is unsupported on this device and log once."""
+        if endpoint in self._unsupported_endpoints:
+            return
+        self._unsupported_endpoints.add(endpoint)
+        _LOGGER.info(
+            "NanoKVM endpoint %s unsupported on this device; skipping future calls (%s)",
+            endpoint,
+            err,
+        )
+
+    async def _fetch_optional(self, endpoint: str, call):
+        """Run an optional endpoint call; return None when the device lacks it.
+
+        Catches only 404 responses and schema parse failures so that transient
+        5xx/timeout errors still surface and trigger retries. Once an endpoint
+        is recorded unsupported it is never called again for this coordinator.
+        """
+        if endpoint in self._unsupported_endpoints:
+            return None
+        try:
+            return await call()
+        except aiohttp.ClientResponseError as err:
+            if err.status != 404:
+                raise
+            self._mark_endpoint_unsupported(endpoint, err)
+            return None
+        except NanoKVMInvalidResponseError as err:
+            self._mark_endpoint_unsupported(endpoint, err)
+            return None
+
     async def _async_fetch_core_data(self) -> None:
         """Fetch required API data used by entities."""
         self.device_info = await self.client.get_info()
         self.hostname_info = await self.client.get_hostname()
         self.hardware_info = await self.client.get_hardware()
         self.gpio_info = await self.client.get_gpio()
-        self.virtual_device_info = await self.client.get_virtual_device_status()
+        self.virtual_device_info = await self._fetch_optional(
+            "/vm/device/virtual", self.client.get_virtual_device_status
+        )
         self.ssh_state = await self.client.get_ssh_state()
         self.mdns_state = await self.client.get_mdns_state()
         self.hid_mode = await self.client.get_hid_mode()
         self.oled_info = await self.client.get_oled_info()
         self.wifi_status = await self.client.get_wifi_status()
-        self.hdmi_state = await self.client.get_hdmi_state()
+        self.hdmi_state = await self._fetch_optional(
+            "/vm/hdmi", self.client.get_hdmi_state
+        )
         self.mouse_jiggler_state = await self.client.get_mouse_jiggler_state()
-        self.swap_size = await self.client.get_swap_size()
+        self.swap_size = await self._fetch_optional(
+            "/vm/swap", self.client.get_swap_size
+        )
         self.tailscale_status = await self.client.get_tailscale_status()
 
     def _async_schedule_app_version_refresh(self) -> None:
@@ -381,7 +420,9 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
                 self.mounted_image = GetMountedImageRsp(file="")
 
             try:
-                self.cdrom_status = await self.client.get_cdrom_status()
+                self.cdrom_status = await self._fetch_optional(
+                    "/storage/cdrom", self.client.get_cdrom_status
+                )
             except NanoKVMApiError as err:
                 _LOGGER.debug(
                     "Failed to get CD-ROM status, retrieving default value: %s", err

--- a/custom_components/nanokvm/switch.py
+++ b/custom_components/nanokvm/switch.py
@@ -70,6 +70,11 @@ def _watchdog_available(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
     return coordinator.supports_watchdog and coordinator.watchdog_enabled is not None
 
 
+def _virtual_device_available(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
+    """Return whether the legacy virtual-device switches apply to this device."""
+    return coordinator.virtual_device_info is not None
+
+
 SWITCHES: tuple[NanoKVMSwitchEntityDescription, ...] = (
     NanoKVMSwitchEntityDescription(
         key="ssh",
@@ -104,6 +109,7 @@ SWITCHES: tuple[NanoKVMSwitchEntityDescription, ...] = (
         value_fn=lambda coordinator: bool(
             coordinator.virtual_device_info and coordinator.virtual_device_info.network
         ),
+        available_fn=_virtual_device_available,
         virtual_device=VirtualDevice.NETWORK,
     ),
     NanoKVMSwitchEntityDescription(
@@ -115,6 +121,7 @@ SWITCHES: tuple[NanoKVMSwitchEntityDescription, ...] = (
         value_fn=lambda coordinator: bool(
             coordinator.virtual_device_info and coordinator.virtual_device_info.disk
         ),
+        available_fn=_virtual_device_available,
         virtual_device=VirtualDevice.DISK,
     ),
     NanoKVMSwitchEntityDescription(

--- a/custom_components/nanokvm/switch.py
+++ b/custom_components/nanokvm/switch.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from nanokvm.models import GpioType, HWVersion, VirtualDevice
+from nanokvm.models import GpioType, VirtualDevice
 
 from .const import (
     DOMAIN,
@@ -53,11 +53,7 @@ def _hdmi_value(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
 
 def _hdmi_available(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
     """Return whether HDMI controls are available."""
-    return (
-        coordinator.hdmi_state is not None
-        and coordinator.hardware_info is not None
-        and coordinator.hardware_info.version == HWVersion.PCIE
-    )
+    return coordinator.supports_hdmi_endpoint and coordinator.hdmi_state is not None
 
 
 def _watchdog_value(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
@@ -72,7 +68,7 @@ def _watchdog_available(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
 
 def _virtual_device_available(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
     """Return whether the legacy virtual-device switches apply to this device."""
-    return coordinator.virtual_device_info is not None
+    return coordinator.supports_legacy_virtual_device_controls
 
 
 SWITCHES: tuple[NanoKVMSwitchEntityDescription, ...] = (


### PR DESCRIPTION
NanoKVM Pro firmware drops four endpoints the coordinator polls on every refresh and returns a different schema on a fifth, so config entry setup fails before any entities are created. This change adds graceful capability probing so the integration loads and functions on both Pro and non-Pro hardware with no user-facing configuration.

Resolves https://github.com/Wouter0100/homeassistant-nanokvm/issues/66

Tested in a real Home Assistant instance.

<img width="669" height="749" alt="image" src="https://github.com/user-attachments/assets/a79a6bd5-093e-4a31-9c0e-827403ea3aa4" />
