### PR TITLE
feat: support NanoKVM Pro WebRTC signaling

### DIFF
--- a/custom_components/nanokvm/camera.py
+++ b/custom_components/nanokvm/camera.py
@@ -89,6 +89,7 @@ class NanoKVMCamera(NanoKVMEntity, Camera):
             hass_provider=lambda: self.hass,
             client_factory=self._create_stream_client,
             authenticate_client=self._authenticate_stream_client,
+            is_pro_hardware=lambda: self.coordinator.is_pro_hardware,
             login_timeout_seconds=LOGIN_TIMEOUT_SECONDS,
             websocket_heartbeat_seconds=WEBSOCKET_HEARTBEAT_SECONDS,
             max_pending_ice_candidates=MAX_PENDING_ICE_CANDIDATES,

--- a/custom_components/nanokvm/camera_webrtc.py
+++ b/custom_components/nanokvm/camera_webrtc.py
@@ -6,7 +6,7 @@ import json
 import logging
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TypedDict
 
 import aiohttp
@@ -23,6 +23,24 @@ from nanokvm.client import NanoKVMClient
 from webrtc_models import RTCIceCandidateInit
 from yarl import URL
 
+from .camera_webrtc_sdp import (
+    MediaKind,
+    ProWebRTCOffer,
+    merge_pro_webrtc_answers,
+    split_pro_webrtc_offer,
+)
+
+_ANSWER_EVENTS: dict[str, MediaKind] = {
+    "video-answer": "video",
+    "audio-answer": "audio",
+}
+_CANDIDATE_EVENTS: dict[str, MediaKind] = {
+    "video-candidate": "video",
+    "audio-candidate": "audio",
+}
+_STATUS_EVENTS = {"video-status", "audio-status", "heartbeat"}
+
+
 @dataclass(slots=True)
 class _NanoKVMWebRTCSession:
     """Internal state for an active NanoKVM WebRTC signaling session."""
@@ -30,6 +48,12 @@ class _NanoKVMWebRTCSession:
     client: NanoKVMClient
     websocket: aiohttp.ClientWebSocketResponse
     reader_task: asyncio.Task[None] | None = None
+    pro_offer: ProWebRTCOffer | None = None
+    pro_answers: dict[MediaKind, str] = field(default_factory=dict)
+    pending_remote_candidates: list[tuple[MediaKind, RTCIceCandidateInit]] = field(
+        default_factory=list
+    )
+    answer_sent: bool = False
 
 
 class _WebSocketTimeoutKwargs(TypedDict, total=False):
@@ -53,6 +77,7 @@ class NanoKVMWebRTCManager:
         hass_provider: Callable[[], HomeAssistant | None],
         client_factory: StreamClientFactory,
         authenticate_client: AuthenticateClientCallable,
+        is_pro_hardware: Callable[[], bool] | None = None,
         login_timeout_seconds: int = 15,
         websocket_heartbeat_seconds: float = 30.0,
         max_pending_ice_candidates: int = 64,
@@ -62,6 +87,7 @@ class NanoKVMWebRTCManager:
         self._hass_provider = hass_provider
         self._client_factory = client_factory
         self._authenticate_client = authenticate_client
+        self._is_pro_hardware = is_pro_hardware or (lambda: False)
         self._login_timeout_seconds = login_timeout_seconds
         self._websocket_heartbeat_seconds = websocket_heartbeat_seconds
         self._max_pending_ice_candidates = max_pending_ice_candidates
@@ -69,10 +95,11 @@ class NanoKVMWebRTCManager:
         self._pending_candidates: dict[str, list[RTCIceCandidateInit]] = {}
         self._session_lock = asyncio.Lock()
 
-    def _webrtc_stream_url(self, base_url: URL) -> str:
+    def _webrtc_stream_url(self, base_url: URL, *, pro: bool) -> str:
         """Build NanoKVM h264 WebRTC websocket URL from API base URL."""
         ws_scheme = "wss" if base_url.scheme == "https" else "ws"
-        return str(base_url.with_scheme(ws_scheme) / "stream/h264")
+        stream_path = "stream/h264/webrtc" if pro else "stream/h264"
+        return str(base_url.with_scheme(ws_scheme) / stream_path)
 
     def _websocket_timeout_kwargs(self) -> _WebSocketTimeoutKwargs:
         """Return websocket timeout kwargs compatible with installed aiohttp."""
@@ -84,7 +111,7 @@ class NanoKVMWebRTCManager:
     async def async_handle_async_webrtc_offer(
         self, offer_sdp: str, session_id: str, send_message: WebRTCSendMessage
     ) -> None:
-        """Handle Home Assistant WebRTC offer using NanoKVM /stream/h264 signaling."""
+        """Handle Home Assistant WebRTC offer using NanoKVM signaling."""
         client = self._client_factory()
         if client is None:
             raise HomeAssistantError("Missing NanoKVM WebRTC client")
@@ -93,9 +120,17 @@ class NanoKVMWebRTCManager:
         if hass is None:
             raise HomeAssistantError("Home Assistant is not ready for WebRTC")
 
+        is_pro = self._is_pro_hardware()
+        pro_offer = split_pro_webrtc_offer(offer_sdp) if is_pro else None
+        if pro_offer is not None and not pro_offer.offers:
+            raise HomeAssistantError(
+                "NanoKVM Pro WebRTC offer does not contain audio or video media"
+            )
+        if pro_offer is not None:
+            self._logger.debug("NanoKVM Pro original HA WebRTC offer SDP:\n%s", offer_sdp)
+
         registered = False
 
-        # Frontend can send ICE candidates before signaling websocket is ready.
         async with self._session_lock:
             self._pending_candidates.setdefault(session_id, [])
 
@@ -108,10 +143,8 @@ class NanoKVMWebRTCManager:
             if client._session is None or client._ssl_config is None:
                 raise RuntimeError("NanoKVM client transport is not initialized")
 
-            # The library does not expose WebRTC signaling yet, so reuse its
-            # configured session, URL, and SSL settings directly.
             websocket = await client._session.ws_connect(
-                self._webrtc_stream_url(client.url),
+                self._webrtc_stream_url(client.url, pro=is_pro),
                 headers={"Cookie": f"nano-kvm-token={client.token}"},
                 heartbeat=self._websocket_heartbeat_seconds,
                 ssl=client._ssl_config,
@@ -121,6 +154,7 @@ class NanoKVMWebRTCManager:
             webrtc_session = _NanoKVMWebRTCSession(
                 client=client,
                 websocket=websocket,
+                pro_offer=pro_offer,
             )
             async with self._session_lock:
                 self._sessions[session_id] = webrtc_session
@@ -130,9 +164,12 @@ class NanoKVMWebRTCManager:
                 self._async_webrtc_reader(session_id, send_message)
             )
 
-            offer_data = json.dumps({"type": "offer", "sdp": offer_sdp})
-            await websocket.send_json({"event": "video-offer", "data": offer_data})
-            await self._async_flush_pending_candidates(session_id, websocket)
+            if pro_offer is None:
+                await self._async_send_legacy_offer(websocket, offer_sdp)
+            else:
+                await self._async_send_pro_offers(websocket, pro_offer)
+
+            await self._async_flush_pending_candidates(session_id)
         except Exception as err:
             if registered:
                 await self._async_close_webrtc_session(session_id)
@@ -144,6 +181,42 @@ class NanoKVMWebRTCManager:
             raise HomeAssistantError(
                 f"Unable to establish NanoKVM WebRTC signaling: {err}"
             ) from err
+
+    async def _async_send_legacy_offer(
+        self, websocket: aiohttp.ClientWebSocketResponse, offer_sdp: str
+    ) -> None:
+        """Send the legacy NanoKVM single video offer."""
+        offer_data = json.dumps({"type": "offer", "sdp": offer_sdp})
+        await websocket.send_json({"event": "video-offer", "data": offer_data})
+
+    async def _async_send_pro_offers(
+        self,
+        websocket: aiohttp.ClientWebSocketResponse,
+        pro_offer: ProWebRTCOffer,
+    ) -> None:
+        """Send split video/audio offers to NanoKVM Pro."""
+        self._logger.debug(
+            "NanoKVM Pro WebRTC offer media sections: %s",
+            ", ".join(pro_offer.expected_kinds),
+        )
+        if "audio" not in pro_offer.offers:
+            self._logger.debug(
+                "Home Assistant WebRTC offer did not include audio; negotiating video-only"
+            )
+
+        for section in pro_offer.media_sections:
+            offer_sdp = pro_offer.offers.get(section.kind)
+            if offer_sdp is None:
+                continue
+            self._logger.debug(
+                "NanoKVM Pro split %s WebRTC offer SDP:\n%s",
+                section.kind,
+                offer_sdp,
+            )
+            offer_data = json.dumps({"type": "offer", "sdp": offer_sdp})
+            await websocket.send_json(
+                {"event": f"{section.kind}-offer", "data": offer_data}
+            )
 
     async def _async_webrtc_reader(
         self, session_id: str, send_message: WebRTCSendMessage
@@ -164,49 +237,24 @@ class NanoKVMWebRTCManager:
                         break
                     continue
 
-                try:
-                    payload = json.loads(msg.data)
-                except (TypeError, json.JSONDecodeError):
-                    self._logger.debug(
-                        "Invalid WebRTC signal message from NanoKVM: %r", msg.data
-                    )
-                    continue
-
-                if not isinstance(payload, dict):
+                payload = self._decode_signal_message(msg.data)
+                if payload is None:
                     continue
 
                 event = payload.get("event")
-                data_raw = payload.get("data")
+                if not isinstance(event, str):
+                    continue
 
                 if event == "heartbeat":
                     continue
-                if not isinstance(data_raw, str):
-                    continue
 
-                try:
-                    data = json.loads(data_raw)
-                except json.JSONDecodeError:
-                    self._logger.debug("Invalid WebRTC signal payload: %r", data_raw)
-                    continue
-
-                if event == "video-answer":
-                    sdp = data.get("sdp") if isinstance(data, dict) else None
-                    if isinstance(sdp, str) and sdp:
-                        send_message(WebRTCAnswer(answer=sdp))
-                elif event == "video-candidate":
-                    if isinstance(data, dict):
-                        try:
-                            candidate = RTCIceCandidateInit.from_dict(data)
-                        except Exception as err:
-                            self._logger.debug(
-                                "Invalid video-candidate payload from NanoKVM: %s (%r)",
-                                err,
-                                data,
-                            )
-                            continue
-                        send_message(WebRTCCandidate(candidate=candidate))
+                data = self._decode_signal_data(payload.get("data"))
+                if session.pro_offer is None:
+                    self._handle_legacy_event(event, data, send_message)
                 else:
-                    self._logger.debug("Unhandled NanoKVM WebRTC event: %s", event)
+                    await self._async_handle_pro_event(
+                        session_id, event, data, send_message
+                    )
         except Exception as err:
             self._logger.error("Error reading NanoKVM WebRTC signaling: %s", err)
             send_message(
@@ -224,6 +272,166 @@ class NanoKVMWebRTCManager:
             )
             await self._async_close_webrtc_session(session_id)
 
+    def _decode_signal_message(self, raw_message: str) -> dict[str, object] | None:
+        """Decode a websocket signaling envelope."""
+        try:
+            payload = json.loads(raw_message)
+        except (TypeError, json.JSONDecodeError):
+            self._logger.debug(
+                "Invalid WebRTC signal message from NanoKVM: %r", raw_message
+            )
+            return None
+
+        if not isinstance(payload, dict):
+            return None
+        return payload
+
+    def _decode_signal_data(self, raw_data: object) -> dict[str, object] | None:
+        """Decode the nested NanoKVM signaling data payload."""
+        if isinstance(raw_data, dict):
+            return raw_data
+        if not isinstance(raw_data, str):
+            return None
+
+        try:
+            data = json.loads(raw_data)
+        except json.JSONDecodeError:
+            self._logger.debug("Invalid WebRTC signal payload: %r", raw_data)
+            return None
+
+        if not isinstance(data, dict):
+            return None
+        return data
+
+    def _handle_legacy_event(
+        self,
+        event: str,
+        data: dict[str, object] | None,
+        send_message: WebRTCSendMessage,
+    ) -> None:
+        """Handle legacy NanoKVM WebRTC events."""
+        if data is None:
+            return
+
+        if event == "video-answer":
+            sdp = data.get("sdp")
+            if isinstance(sdp, str) and sdp:
+                send_message(WebRTCAnswer(answer=sdp))
+            return
+
+        if event == "video-candidate":
+            candidate = self._candidate_from_payload(event, data)
+            if candidate is not None:
+                send_message(WebRTCCandidate(candidate=candidate))
+            return
+
+        self._logger.debug("Unhandled NanoKVM WebRTC event: %s", event)
+
+    async def _async_handle_pro_event(
+        self,
+        session_id: str,
+        event: str,
+        data: dict[str, object] | None,
+        send_message: WebRTCSendMessage,
+    ) -> None:
+        """Handle NanoKVM Pro split video/audio WebRTC events."""
+        if event in _STATUS_EVENTS:
+            self._logger.debug("NanoKVM Pro WebRTC status event %s: %s", event, data)
+            return
+
+        if (kind := _ANSWER_EVENTS.get(event)) is not None:
+            if data is None:
+                return
+            sdp = data.get("sdp")
+            if isinstance(sdp, str) and sdp:
+                await self._async_store_pro_answer(
+                    session_id, kind, sdp, send_message
+                )
+            return
+
+        if (kind := _CANDIDATE_EVENTS.get(event)) is not None:
+            if data is None:
+                return
+            candidate = self._candidate_from_payload(event, data)
+            if candidate is not None:
+                await self._async_store_pro_candidate(
+                    session_id, kind, candidate, send_message
+                )
+            return
+
+        self._logger.debug("Unhandled NanoKVM Pro WebRTC event: %s", event)
+
+    async def _async_store_pro_answer(
+        self,
+        session_id: str,
+        kind: MediaKind,
+        sdp: str,
+        send_message: WebRTCSendMessage,
+    ) -> None:
+        """Store a Pro answer and emit the merged HA answer when complete."""
+        answer: str | None = None
+        pending_candidates: list[RTCIceCandidateInit] = []
+
+        async with self._session_lock:
+            session = self._sessions.get(session_id)
+            if (
+                session is None
+                or session.pro_offer is None
+                or session.answer_sent
+                or kind not in session.pro_offer.offers
+            ):
+                return
+
+            session.pro_answers[kind] = sdp
+            if set(session.pro_offer.expected_kinds).issubset(session.pro_answers):
+                answer = merge_pro_webrtc_answers(
+                    session.pro_offer, session.pro_answers
+                )
+                pending_candidates = [
+                    mapped
+                    for candidate_kind, candidate in session.pending_remote_candidates
+                    if (
+                        mapped := session.pro_offer.home_assistant_candidate_for_kind(
+                            candidate_kind, candidate
+                        )
+                    )
+                    is not None
+                ]
+                session.pending_remote_candidates.clear()
+                session.answer_sent = True
+
+        if answer is None:
+            return
+
+        send_message(WebRTCAnswer(answer=answer))
+        for candidate in pending_candidates:
+            send_message(WebRTCCandidate(candidate=candidate))
+
+    async def _async_store_pro_candidate(
+        self,
+        session_id: str,
+        kind: MediaKind,
+        candidate: RTCIceCandidateInit,
+        send_message: WebRTCSendMessage,
+    ) -> None:
+        """Store or emit a Pro ICE candidate with HA media-section mapping."""
+        candidate_to_send: RTCIceCandidateInit | None = None
+
+        async with self._session_lock:
+            session = self._sessions.get(session_id)
+            if session is None or session.pro_offer is None:
+                return
+
+            if session.answer_sent:
+                candidate_to_send = session.pro_offer.home_assistant_candidate_for_kind(
+                    kind, candidate
+                )
+            else:
+                session.pending_remote_candidates.append((kind, candidate))
+
+        if candidate_to_send is not None:
+            send_message(WebRTCCandidate(candidate=candidate_to_send))
+
     async def async_on_webrtc_candidate(
         self, session_id: str, candidate: RTCIceCandidateInit
     ) -> None:
@@ -237,15 +445,38 @@ class NanoKVMWebRTCManager:
                 return
 
         try:
-            await self._async_send_candidate(session.websocket, candidate)
+            await self._async_send_candidate_for_session(session, candidate)
         except Exception as err:
             raise HomeAssistantError(
                 f"Unable to forward WebRTC candidate to NanoKVM: {err}"
             ) from err
 
+    async def _async_send_candidate_for_session(
+        self,
+        session: _NanoKVMWebRTCSession,
+        candidate: RTCIceCandidateInit,
+    ) -> None:
+        """Send one frontend ICE candidate to legacy or Pro signaling."""
+        if session.pro_offer is None:
+            await self._async_send_candidate(
+                session.websocket, "video-candidate", candidate
+            )
+            return
+
+        for kind in session.pro_offer.kinds_for_candidate(candidate):
+            mapped_candidate = session.pro_offer.upstream_candidate_for_kind(
+                kind, candidate
+            )
+            if mapped_candidate is None:
+                continue
+            await self._async_send_candidate(
+                session.websocket, f"{kind}-candidate", mapped_candidate
+            )
+
     async def _async_send_candidate(
         self,
         websocket: aiohttp.ClientWebSocketResponse,
+        event: str,
         candidate: RTCIceCandidateInit,
     ) -> None:
         """Send a single ICE candidate to NanoKVM signaling websocket."""
@@ -257,25 +488,45 @@ class NanoKVMWebRTCManager:
         if candidate.sdp_m_line_index is not None:
             payload["sdpMLineIndex"] = candidate.sdp_m_line_index
         if candidate.user_fragment is not None:
-            # NanoKVM (Go/Pion) expects this exact key.
             payload["usernameFragment"] = candidate.user_fragment
 
         await websocket.send_json(
             {
-                "event": "video-candidate",
+                "event": event,
                 "data": json.dumps(payload),
             }
         )
 
-    async def _async_flush_pending_candidates(
-        self, session_id: str, websocket: aiohttp.ClientWebSocketResponse
-    ) -> None:
+    async def _async_flush_pending_candidates(self, session_id: str) -> None:
         """Flush candidates queued before websocket session became active."""
         async with self._session_lock:
+            session = self._sessions.get(session_id)
             pending = self._pending_candidates.pop(session_id, [])
 
+        if session is None:
+            return
+
         for candidate in pending:
-            await self._async_send_candidate(websocket, candidate)
+            await self._async_send_candidate_for_session(session, candidate)
+
+    def _candidate_from_payload(
+        self, event: str, data: dict[str, object]
+    ) -> RTCIceCandidateInit | None:
+        """Build a WebRTC candidate from NanoKVM signaling payload."""
+        candidate_data = dict(data)
+        if "usernameFragment" in candidate_data and "userFragment" not in candidate_data:
+            candidate_data["userFragment"] = candidate_data["usernameFragment"]
+
+        try:
+            return RTCIceCandidateInit.from_dict(candidate_data)
+        except Exception as err:
+            self._logger.debug(
+                "Invalid %s payload from NanoKVM: %s (%r)",
+                event,
+                err,
+                data,
+            )
+            return None
 
     async def _async_close_webrtc_session(self, session_id: str) -> None:
         """Close and cleanup an active NanoKVM WebRTC signaling session."""

--- a/custom_components/nanokvm/camera_webrtc_sdp.py
+++ b/custom_components/nanokvm/camera_webrtc_sdp.py
@@ -1,0 +1,319 @@
+"""SDP helpers for NanoKVM Pro split WebRTC signaling."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from webrtc_models import RTCIceCandidateInit
+
+MediaKind = Literal["audio", "video"]
+
+_SUPPORTED_KINDS: tuple[MediaKind, ...] = ("audio", "video")
+_TRANSPORT_SESSION_PREFIXES = (
+    "a=ice-ufrag:",
+    "a=ice-pwd:",
+    "a=ice-options:",
+    "a=fingerprint:",
+    "a=setup:",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ProMediaSection:
+    """Media section metadata from the original Home Assistant offer."""
+
+    kind: MediaKind
+    mid: str
+    index: int
+    lines: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ProWebRTCOffer:
+    """Split Pro WebRTC offers and mapping back to the original HA offer."""
+
+    offers: dict[MediaKind, str]
+    media_sections: tuple[ProMediaSection, ...]
+
+    @property
+    def expected_kinds(self) -> tuple[MediaKind, ...]:
+        """Return media kinds expected from the NanoKVM Pro."""
+        return tuple(section.kind for section in self.media_sections)
+
+    def section_for_kind(self, kind: MediaKind) -> ProMediaSection | None:
+        """Return the original offer section for a media kind."""
+        for section in self.media_sections:
+            if section.kind == kind:
+                return section
+        return None
+
+    def kinds_for_candidate(
+        self, candidate: RTCIceCandidateInit
+    ) -> tuple[MediaKind, ...]:
+        """Return Pro media kinds that should receive a frontend candidate."""
+        if candidate.sdp_mid is not None:
+            for section in self.media_sections:
+                if section.mid == str(candidate.sdp_mid):
+                    return (section.kind,)
+
+        if candidate.sdp_m_line_index is not None:
+            for section in self.media_sections:
+                if section.index == candidate.sdp_m_line_index:
+                    return (section.kind,)
+
+        return self.expected_kinds
+
+    def upstream_candidate_for_kind(
+        self, kind: MediaKind, candidate: RTCIceCandidateInit
+    ) -> RTCIceCandidateInit | None:
+        """Map a Home Assistant candidate into the split Pro peer connection."""
+        section = self.section_for_kind(kind)
+        if section is None:
+            return None
+
+        return RTCIceCandidateInit(
+            candidate.candidate,
+            sdp_mid="0",
+            sdp_m_line_index=0,
+            user_fragment=candidate.user_fragment,
+        )
+
+    def home_assistant_candidate_for_kind(
+        self, kind: MediaKind, candidate: RTCIceCandidateInit
+    ) -> RTCIceCandidateInit | None:
+        """Map a Pro candidate back into the original HA media section."""
+        section = self.section_for_kind(kind)
+        if section is None:
+            return None
+
+        return RTCIceCandidateInit(
+            candidate.candidate,
+            sdp_mid=section.mid,
+            sdp_m_line_index=section.index,
+            user_fragment=candidate.user_fragment,
+        )
+
+
+def split_pro_webrtc_offer(offer_sdp: str) -> ProWebRTCOffer:
+    """Split a combined HA offer into Pro video/audio websocket offers."""
+    session_lines, media_lines = _split_sdp_sections(offer_sdp)
+    media_sections: list[ProMediaSection] = []
+    offers: dict[MediaKind, str] = {}
+
+    for index, lines in enumerate(media_lines):
+        kind = _media_kind(lines)
+        if kind not in _SUPPORTED_KINDS or kind in offers:
+            continue
+
+        mid = _media_mid(lines, fallback=str(index))
+        section = ProMediaSection(
+            kind=kind,
+            mid=mid,
+            index=index,
+            lines=tuple(lines),
+        )
+        media_sections.append(section)
+        offers[kind] = _join_sdp_sections(
+            _single_media_session_lines(session_lines),
+            (_replace_mid(section.lines, "0"),),
+        )
+
+    return ProWebRTCOffer(offers=offers, media_sections=tuple(media_sections))
+
+
+def merge_pro_webrtc_answers(
+    offer: ProWebRTCOffer,
+    answers: dict[MediaKind, str],
+    *,
+    reject_missing: bool = False,
+) -> str:
+    """Merge separate Pro video/audio answers into one HA-compatible answer."""
+    if not answers:
+        raise ValueError("No NanoKVM Pro WebRTC answers received")
+
+    first_answer = next(iter(answers.values()))
+    first_session_lines, _ = _split_sdp_sections(first_answer)
+    merged_session_lines = _merged_session_lines(first_session_lines)
+    merged_media_lines: list[tuple[str, ...]] = []
+
+    for section in offer.media_sections:
+        answer_sdp = answers.get(section.kind)
+        if answer_sdp is None:
+            if not reject_missing:
+                raise ValueError(f"Missing {section.kind} WebRTC answer")
+            merged_media_lines.append(_rejected_media_section(section))
+            continue
+
+        answer_session_lines, answer_media_sections = _split_sdp_sections(answer_sdp)
+        answer_media = _first_media_section_for_kind(
+            answer_media_sections, section.kind
+        )
+        if answer_media is None:
+            raise ValueError(f"NanoKVM Pro {section.kind} answer has no media section")
+
+        media_with_original_mid = _replace_mid(answer_media, section.mid)
+        merged_media_lines.append(
+            _with_media_transport_lines(
+                media_with_original_mid,
+                answer_session_lines,
+            )
+        )
+
+    return _join_sdp_sections(merged_session_lines, tuple(merged_media_lines))
+
+
+def _split_sdp_sections(sdp: str) -> tuple[tuple[str, ...], tuple[tuple[str, ...], ...]]:
+    """Split SDP into session-level lines and media sections."""
+    lines = tuple(
+        line
+        for line in sdp.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+        if line
+    )
+    session_lines: list[str] = []
+    media_sections: list[list[str]] = []
+    current_media: list[str] | None = None
+
+    for line in lines:
+        if line.startswith("m="):
+            current_media = [line]
+            media_sections.append(current_media)
+        elif current_media is None:
+            session_lines.append(line)
+        else:
+            current_media.append(line)
+
+    return tuple(session_lines), tuple(tuple(section) for section in media_sections)
+
+
+def _join_sdp_sections(
+    session_lines: tuple[str, ...],
+    media_sections: tuple[tuple[str, ...], ...],
+) -> str:
+    """Join SDP lines using CRLF endings."""
+    lines = list(session_lines)
+    for media_section in media_sections:
+        lines.extend(media_section)
+    return "\r\n".join(lines) + "\r\n"
+
+
+def _media_kind(lines: tuple[str, ...]) -> MediaKind | None:
+    """Return the kind of an SDP media section."""
+    if not lines or not lines[0].startswith("m="):
+        return None
+
+    kind = lines[0][2:].split(maxsplit=1)[0]
+    if kind in _SUPPORTED_KINDS:
+        return kind
+    return None
+
+
+def _media_mid(lines: tuple[str, ...], *, fallback: str) -> str:
+    """Return the SDP media section MID."""
+    for line in lines:
+        if line.startswith("a=mid:"):
+            return line.removeprefix("a=mid:")
+    return fallback
+
+
+def _single_media_session_lines(session_lines: tuple[str, ...]) -> tuple[str, ...]:
+    """Return session lines for one split Pro peer connection."""
+    replaced_bundle = False
+    filtered: list[str] = []
+
+    for line in session_lines:
+        if line.startswith("a=group:BUNDLE"):
+            if not replaced_bundle:
+                filtered.append("a=group:BUNDLE 0")
+                replaced_bundle = True
+            continue
+        filtered.append(line)
+
+    return tuple(filtered)
+
+
+def _merged_session_lines(session_lines: tuple[str, ...]) -> tuple[str, ...]:
+    """Return session lines safe for answers built from separate peer connections."""
+    merged: list[str] = []
+    for line in session_lines:
+        if line.startswith("a=group:BUNDLE"):
+            continue
+        if _is_transport_session_line(line):
+            continue
+        merged.append(line)
+    return tuple(merged)
+
+
+def _first_media_section_for_kind(
+    media_sections: tuple[tuple[str, ...], ...],
+    kind: MediaKind,
+) -> tuple[str, ...] | None:
+    """Return the first answer media section for the requested kind."""
+    for section in media_sections:
+        if _media_kind(section) == kind:
+            return section
+    return None
+
+
+def _replace_mid(lines: tuple[str, ...], mid: str) -> tuple[str, ...]:
+    """Replace or add a media section MID."""
+    replaced = False
+    result: list[str] = []
+    for line in lines:
+        if line.startswith("a=mid:"):
+            result.append(f"a=mid:{mid}")
+            replaced = True
+        else:
+            result.append(line)
+
+    if not replaced:
+        result.append(f"a=mid:{mid}")
+
+    return tuple(result)
+
+
+def _with_media_transport_lines(
+    media_lines: tuple[str, ...],
+    session_lines: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Move per-answer transport attributes into the merged media section."""
+    existing_prefixes = {
+        prefix for prefix in _TRANSPORT_SESSION_PREFIXES if _has_prefix(media_lines, prefix)
+    }
+    result = list(media_lines)
+
+    for line in session_lines:
+        for prefix in _TRANSPORT_SESSION_PREFIXES:
+            if prefix in existing_prefixes or not line.startswith(prefix):
+                continue
+            result.append(line)
+            existing_prefixes.add(prefix)
+            break
+
+    return tuple(result)
+
+
+def _rejected_media_section(section: ProMediaSection) -> tuple[str, ...]:
+    """Build a rejected answer media section for a missing optional answer."""
+    media_line_parts = section.lines[0].split()
+    if len(media_line_parts) >= 2:
+        media_line_parts[1] = "0"
+    result = [" ".join(media_line_parts), f"a=mid:{section.mid}", "a=inactive"]
+
+    for line in section.lines:
+        if line.startswith("c="):
+            result.insert(1, line)
+            break
+    else:
+        result.insert(1, "c=IN IP4 0.0.0.0")
+
+    return tuple(result)
+
+
+def _has_prefix(lines: tuple[str, ...], prefix: str) -> bool:
+    """Return whether any SDP line starts with prefix."""
+    return any(line.startswith(prefix) for line in lines)
+
+
+def _is_transport_session_line(line: str) -> bool:
+    """Return whether a session line carries transport data for one peer connection."""
+    return any(line.startswith(prefix) for prefix in _TRANSPORT_SESSION_PREFIXES)


### PR DESCRIPTION
## Summary

Adds WebRTC signaling support for NanoKVM Pro devices.

This updates the camera WebRTC flow to detect Pro hardware, use the Pro WebRTC endpoint, split Home Assistant offers into separate audio/video NanoKVM offers, and merge the returned Pro answers back into a Home Assistant-compatible SDP answer.

## Changes

- Route Pro devices to `/stream/h264/webrtc`
- Keep legacy devices on the existing `/stream/h264` signaling path
- Add SDP helpers for splitting Pro offers and merging Pro answers
- Map ICE candidates between Home Assistant media sections and NanoKVM Pro split peer connections
- Handle Pro audio/video answer, candidate, status, and heartbeat events
