### PR TITLE
Add NanoKVM Pro support and update documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,13 +35,17 @@ The integration follows the standard structure for a Home Assistant
 
 - **`coordinator.py`**: Hosts `NanoKVMDataUpdateCoordinator`.
   - Central polling logic (`_async_update_data`) and API fetch helpers.
-  - Handles reauthentication, storage-state fetches, and SSH metric refresh.
+  - Handles reauthentication, storage-state fetches, optional NanoKVM Pro
+    state, dynamic media/network/SSH entities, and SSH metric refresh.
+  - Gates non-Pro-only endpoints such as swap size, CD-ROM state, HDMI output,
+    and non-Pro virtual disk controls.
 
 - **`entity.py`**: Defines `NanoKVMEntity` base class.
   - Shared entity behavior (`unique_id`, `device_info`) for all platforms.
 
 - **`services.py`**: Service schemas, registration, and handlers.
-  - Implements all `nanokvm.*` service behavior and unregister logic.
+  - Implements all `nanokvm.*` service behavior, response services, and
+    unregister logic.
 
 - **`config_flow.py`**: Manages the user configuration flow in Home Assistant.
   - Implements `ConfigFlow` for manual setup and zeroconf discovery.
@@ -60,6 +64,9 @@ The integration follows the standard structure for a Home Assistant
 - **`ssh_metrics.py`**: SSH metrics collection implementation used by the
   coordinator.
 
+- **`led.py`**: Shared NanoKVM Pro LED strip validation and config helpers.
+  - Enforces LED brightness and bead-count constraints for entities/services.
+
 - **`manifest.json`**: Integration metadata.
   - Domain, name, version, dependencies (including `zeroconf`).
   - PyPI requirement (`nanokvm`).
@@ -75,6 +82,8 @@ Assistant entity type:
 - `button.py`
 - `camera.py`
 - `camera_webrtc.py` (WebRTC helper used by the camera platform)
+- `camera_webrtc_sdp.py` (NanoKVM Pro SDP split/merge helpers)
+- `number.py`
 - `select.py`
 - `sensor.py`
 - `switch.py`
@@ -112,6 +121,13 @@ Each platform follows a similar pattern:
 - **Coordinator pattern**:
   `DataUpdateCoordinator` provides one polling path and shared state for all
   entities.
+- **Optional and dynamic entities**:
+  Some entities are created only after the coordinator sees supporting state,
+  such as mounted media, active wired/wireless connections, or SSH metrics.
+- **NanoKVM Pro compatibility**:
+  Pro devices expose several APIs with different schemas from non-Pro models.
+  Keep Pro-specific polling optional and keep non-Pro-only entities gated by
+  hardware support.
 - **Declarative entities**:
   Dataclass-based entity descriptions keep entity definitions compact.
 - **`nanokvm` library boundary**:
@@ -127,12 +143,16 @@ Each platform follows a similar pattern:
 
 Run these checks locally before pushing:
 
-1. Python lint:
-   - `ruff check custom_components/nanokvm`
-   - If needed: `.\venv\Scripts\python -m ruff check custom_components/nanokvm`
-2. Validate metadata JSON:
-   - `Get-Content hacs.json | ConvertFrom-Json > $null`
-   - `Get-Content custom_components/nanokvm/manifest.json | ConvertFrom-Json > $null`
+1. Python checks:
+   - `python -m ruff check custom_components/nanokvm`
+   - `python -m py_compile custom_components/nanokvm/*.py`
+2. Validate JSON metadata, strings, and translations:
+   - `python -m json.tool hacs.json`
+   - `python -m json.tool custom_components/nanokvm/manifest.json`
+   - `python -m json.tool custom_components/nanokvm/strings.json`
+   - `python -m json.tool custom_components/nanokvm/translations/en.json`
+   - `python -m json.tool custom_components/nanokvm/translations/fr.json`
+   - `python -m json.tool custom_components/nanokvm/translations/pt-BR.json`
 3. Verify the integration against a Home Assistant test instance and inspect logs.
 
 ## Required GitHub Workflows

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,15 +20,24 @@ Recommended flow:
 - Keep changes focused and small when possible.
 - AI-assisted coding is welcome, but contributors are responsible for
   understanding, reviewing, and validating generated changes.
-- Update docs/translations when behavior or user-facing text changes.
+- Update README, SERVICES, strings, and translations together when behavior,
+  services, entities, or user-facing text changes.
 - Add tests for bug fixes and new behavior when practical.
 
 ## Validation
 
 Before opening a PR, run:
 
-1. `ruff check custom_components/nanokvm`
-2. Test the integration on a Home Assistant instance (if relevant)
+1. `python -m ruff check custom_components/nanokvm`
+2. `python -m py_compile custom_components/nanokvm/*.py`
+3. `python -m json.tool hacs.json`
+4. `python -m json.tool custom_components/nanokvm/manifest.json`
+5. `python -m json.tool custom_components/nanokvm/strings.json`
+6. `python -m json.tool custom_components/nanokvm/translations/en.json`
+7. `python -m json.tool custom_components/nanokvm/translations/fr.json`
+8. `python -m json.tool custom_components/nanokvm/translations/pt-BR.json`
+
+When behavior changes, also test the integration on a Home Assistant instance.
 
 CI must pass on the PR branch:
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ device settings, diagnostics, services, and camera streaming in Home Assistant.
 
 | Area | Capabilities |
 | --- | --- |
-| Power and hardware | Power/reset actions, status LEDs, HDMI output control (PCI-E) |
-| Device settings | SSH, mDNS, HID mode, OLED timeout, swap size, mouse jiggler, watchdog |
-| Virtual devices | Virtual network and virtual disk switches |
-| Monitoring | Mounted image, CD-ROM mode, Tailscale, Wi-Fi |
+| Power and hardware | Power/reset actions, status LEDs, HDMI output control (PCI-E), Pro HDMI capture/passthrough |
+| Device settings | SSH, mDNS, HID mode, OLED timeout, swap size, mouse jiggler, watchdog, Pro low power, Pro LCD time format |
+| Virtual devices | Virtual network, non-Pro virtual disk switch, Pro virtual mic, Pro virtual disk type |
+| Pro LED strip | On/off, brightness, horizontal bead count, vertical bead count |
+| Monitoring | Mounted image, CD-ROM mode, Tailscale, Wi-Fi, wired/wireless IP diagnostics, Pro time/static IP state |
 | Updates | Application version reporting and install action |
 | SSH diagnostics | Uptime, CPU temp, memory/storage usage when SSH is enabled |
-| Camera | HDMI still snapshots and native WebRTC streaming |
+| Camera | HDMI still snapshots on non-Pro models and native WebRTC streaming |
 
 ## Installation
 
@@ -66,18 +67,20 @@ Notes:
 
 - Host updates from discovery are disabled when **Use static host only** is enabled.
 - Camera stream availability depends on HDMI input/source status.
+- NanoKVM Pro still snapshots are skipped to avoid interrupting WebRTC video mode.
 - Feature-specific entities only appear when the device reports support for them.
 
 ## Entities
 
 | Platform | Highlights |
 | --- | --- |
-| Binary sensor | Power LED, HDD LED, Wi-Fi connected, CD-ROM mode |
-| Button | Power/Reset buttons, reboot, reset HID/HDMI |
-| Camera | HDMI stream camera with still snapshots and WebRTC |
-| Select | HID mode, Mouse Jiggler, OLED timeout, Swap size |
-| Sensor | Mounted image, Tailscale, SSH diagnostics |
-| Switch | Power, SSH, mDNS, Virtual network/disk, HDMI output, watchdog |
+| Binary sensor | Power LED, HDD LED, Wi-Fi/wired connected, CD-ROM mode, Pro static IP enabled, Pro time synchronized |
+| Button | Power/Reset buttons, reboot, reset HID/HDMI, Pro sync time |
+| Camera | HDMI stream camera with WebRTC and non-Pro still snapshots |
+| Number | Pro LED brightness, horizontal beads, vertical beads |
+| Select | HID mode, Mouse Jiggler, OLED timeout, Swap size, Pro LCD time format, Pro virtual disk type |
+| Sensor | IP address, wired/wireless IP address, mounted image, Tailscale, SSH diagnostics |
+| Switch | Power, SSH, mDNS, virtual network/disk, HDMI output, watchdog, Pro HDMI capture/passthrough, Pro low power, Pro LED strip, Pro virtual mic |
 | Update | Application version and install action |
 
 Notes:
@@ -87,6 +90,7 @@ Notes:
 - Wi-Fi entities only appear when the device reports Wi-Fi support.
 - SSH diagnostics appear after SSH is enabled on the NanoKVM.
 - The watchdog switch requires SSH and NanoKVM application version `2.2.2` or newer.
+- Pro LED bead counts must satisfy `horizontal + (2 * vertical) <= 150`.
 
 ## Hardware Compatibility
 
@@ -95,22 +99,26 @@ Notes:
 | HDMI switch/button controls | PCI-E models |
 | HDD LED binary sensor | Alpha models |
 | SSH diagnostic sensors | Any model with SSH enabled |
-| Swap size, CD-ROM mode, virtual network/disk switches | Non-Pro models |
+| Swap size, CD-ROM mode, virtual disk switch | Non-Pro models |
+| Virtual network switch | Non-Pro and Pro models |
+| HDMI capture/passthrough, low power, LED strip, virtual mic, LCD time format, sync time | Pro models |
+| Wired/wireless IP sensors | Created when that connection type is active |
 
 ### NanoKVM Pro
 
-NanoKVM Pro devices are supported. Because the Pro firmware no longer
-exposes the `/vm/swap`, `/vm/hdmi`, and `/storage/cdrom` endpoints and
-uses a different schema on `/vm/device/virtual`, the following entities
-are hidden on Pro:
+NanoKVM Pro devices are supported through the `nanokvm` Python library.
+The integration exposes Pro controls for HDMI capture/passthrough, low power,
+LED strip configuration, virtual network, virtual microphone, virtual disk
+type, LCD time format, sync time, static IP state, and time synchronization
+state.
+
+Because the Pro firmware does not expose the same endpoints as non-Pro models,
+these non-Pro entities are hidden on Pro:
 
 - Swap size select
 - HDMI output switch and Reset HDMI button
 - CD-ROM Mode binary sensor
-- Virtual Network and Virtual Disk switches
-
-All other entities work. Planned Pro-specific additions will be documented
-in a future update.
+- Virtual Disk switch
 
 ## Services
 
@@ -126,11 +134,19 @@ For full call examples, see [`SERVICES.md`](SERVICES.md).
 | `reset_hid` | `host` | Reset HID subsystem |
 | `wake_on_lan` | `host`, `mac` | Send Wake-on-LAN packet |
 | `set_mouse_jiggler` | `host`, `enabled`, `mode` | Set mouse jiggler state |
+| `set_led_strip` | `host`, `on`, `brightness`, `horizontal_count`, `vertical_count` | Set NanoKVM Pro LED strip state |
+| `scan_wifi` | `host` | Scan Wi-Fi networks and return the Pro response |
+| `list_images` | `host` | Return available NanoKVM images |
+| `is_image_download_enabled` | `host` | Return whether image downloading is enabled |
+| `get_image_download_status` | `host` | Return image download status |
+| `list_custom_edids` | `host` | Return custom EDIDs available on NanoKVM Pro |
 
 Notes:
 
 - `push_button.duration` range is `100-5000` ms.
+- `set_led_strip.brightness` range is `0-100`; LED beads must satisfy `horizontal + (2 * vertical) <= 150`.
 - `host` is optional when one NanoKVM is configured and required when multiple devices are configured.
+- Response services return structured data to callers that request a response.
 
 ## Example Automation
 
@@ -156,6 +172,8 @@ automation:
 | Missing entities | Some entities only appear after the related feature is available (for example SSH enabled or media mounted) |
 | No SSH sensors | Enable SSH on NanoKVM |
 | No HDMI controls | HDMI controls only appear on PCI-E hardware |
+| No Pro still image | Pro snapshots are intentionally skipped to avoid interrupting WebRTC video |
+| Missing wired/wireless IP sensor | The sensor appears after the device reports an active address for that connection type |
 
 ## Supported Languages
 

--- a/SERVICES.md
+++ b/SERVICES.md
@@ -1,6 +1,11 @@
 # NanoKVM Service Examples
 
 All service calls use the `nanokvm` domain.
+The `host` field is optional when one NanoKVM is configured and required when
+multiple NanoKVM devices are configured.
+
+Response services return structured data. In automations or scripts, use
+`response_variable` when you need to consume the returned data.
 
 ## `nanokvm.push_button`
 
@@ -124,4 +129,121 @@ data:
   host: "192.168.1.50"
   enabled: true
   mode: absolute
+```
+
+## `nanokvm.set_led_strip`
+
+Configure NanoKVM Pro LED strip state.
+
+Parameters:
+
+- `host`: optional target host; required when multiple NanoKVM devices are configured
+- `on`: `true` or `false` (optional)
+- `brightness`: brightness percentage from `0` to `100` (optional)
+- `horizontal_count`: horizontal LED bead count, minimum `1` (optional)
+- `vertical_count`: vertical LED bead count, minimum `1` (optional)
+
+At least one of `on`, `brightness`, `horizontal_count`, or `vertical_count`
+is required. Omitted values are preserved from the current LED strip state.
+The bead counts must satisfy:
+
+```text
+horizontal_count + (2 * vertical_count) <= 150
+```
+
+Example:
+
+```yaml
+service: nanokvm.set_led_strip
+data:
+  host: "192.168.1.50"
+  on: true
+  brightness: 75
+  horizontal_count: 10
+  vertical_count: 70
+```
+
+## `nanokvm.scan_wifi`
+
+Scan nearby Wi-Fi networks and return the NanoKVM Pro response.
+
+Parameters:
+
+- `host`: optional target host; required when multiple NanoKVM devices are configured
+
+Example:
+
+```yaml
+service: nanokvm.scan_wifi
+data:
+  host: "192.168.1.50"
+response_variable: wifi_scan
+```
+
+## `nanokvm.list_images`
+
+List images available on the NanoKVM.
+
+Parameters:
+
+- `host`: optional target host; required when multiple NanoKVM devices are configured
+
+Example:
+
+```yaml
+service: nanokvm.list_images
+data:
+  host: "192.168.1.50"
+response_variable: images
+```
+
+## `nanokvm.is_image_download_enabled`
+
+Return whether image downloading is enabled on the NanoKVM.
+
+Parameters:
+
+- `host`: optional target host; required when multiple NanoKVM devices are configured
+
+Example:
+
+```yaml
+service: nanokvm.is_image_download_enabled
+data:
+  host: "192.168.1.50"
+response_variable: image_download_enabled
+```
+
+## `nanokvm.get_image_download_status`
+
+Return the current NanoKVM image download status.
+
+Parameters:
+
+- `host`: optional target host; required when multiple NanoKVM devices are configured
+
+Example:
+
+```yaml
+service: nanokvm.get_image_download_status
+data:
+  host: "192.168.1.50"
+response_variable: image_download_status
+```
+
+## `nanokvm.list_custom_edids`
+
+List custom EDIDs available on a NanoKVM Pro.
+
+Parameters:
+
+- `host`: optional target host; required when multiple NanoKVM devices are configured
+
+Example:
+
+```yaml
+service: nanokvm.list_custom_edids
+data:
+  host: "192.168.1.50"
+response_variable: custom_edids
 ```

--- a/custom_components/nanokvm/__init__.py
+++ b/custom_components/nanokvm/__init__.py
@@ -24,6 +24,7 @@ PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.CAMERA,
+    Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,

--- a/custom_components/nanokvm/binary_sensor.py
+++ b/custom_components/nanokvm/binary_sensor.py
@@ -20,8 +20,10 @@ from nanokvm.models import HWVersion
 from .const import (
     DOMAIN,
     ICON_DISK,
+    ICON_NETWORK,
     ICON_POWER,
     SIGNAL_NEW_MEDIA_ENTITIES,
+    SIGNAL_NEW_NETWORK_ENTITIES,
     ICON_WIFI,
 )
 from .coordinator import NanoKVMDataUpdateCoordinator
@@ -64,6 +66,31 @@ def _has_mounted_image(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
 def _cdrom_supported(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
     """Return whether the dedicated /storage/cdrom endpoint exists on this device."""
     return coordinator.supports_cdrom_endpoint
+
+
+def _has_connection_type(
+    coordinator: NanoKVMDataUpdateCoordinator, connection_type: str
+) -> bool:
+    """Return whether an IP connection type is active."""
+    return any(
+        address.addr and address.type.casefold() == connection_type
+        for address in coordinator.device_info.ips
+    )
+
+
+def _wired_active(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
+    """Return whether a wired network connection is active."""
+    return _has_connection_type(coordinator, "wired")
+
+
+def _static_ip_available(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
+    """Return whether Pro static IP state is available."""
+    return coordinator.is_pro_hardware and coordinator.static_ip is not None
+
+
+def _time_status_available(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
+    """Return whether Pro time synchronization state is available."""
+    return coordinator.is_pro_hardware and coordinator.time_status is not None
 
 
 MEDIA_BINARY_SENSORS: tuple[NanoKVMBinarySensorEntityDescription, ...] = (
@@ -118,6 +145,40 @@ BINARY_SENSORS: tuple[NanoKVMBinarySensorEntityDescription, ...] = (
         available_fn=_wifi_supported,
         should_create_fn=_wifi_supported,
     ),
+    NanoKVMBinarySensorEntityDescription(
+        key="wired_connected",
+        name="Wired Connected",
+        translation_key="wired_connected",
+        icon=ICON_NETWORK,
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_wired_active,
+        should_create_fn=_wired_active,
+    ),
+    NanoKVMBinarySensorEntityDescription(
+        key="static_ip_enabled",
+        name="Static IP Enabled",
+        translation_key="static_ip_enabled",
+        icon=ICON_NETWORK,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coordinator: bool(
+            coordinator.static_ip and coordinator.static_ip.enabled
+        ),
+        available_fn=_static_ip_available,
+        should_create_fn=_static_ip_available,
+    ),
+    NanoKVMBinarySensorEntityDescription(
+        key="time_synchronized",
+        name="Time Synchronized",
+        translation_key="time_synchronized",
+        icon="mdi:clock-check-outline",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coordinator: bool(
+            coordinator.time_status and coordinator.time_status.is_synchronized
+        ),
+        available_fn=_time_status_available,
+        should_create_fn=_time_status_available,
+    ),
 )
 
 
@@ -162,11 +223,45 @@ async def async_setup_entry(
     if _has_mounted_image(coordinator):
         async_add_media_binary_sensors()
 
+    network_entities_added = {
+        description.key
+        for description in BINARY_SENSORS
+        if description.should_create_fn(coordinator)
+    }
+
+    @callback
+    def async_add_network_binary_sensors(connection_type: str) -> None:
+        """Add network binary sensors when a connection type appears."""
+        if connection_type != "wired":
+            return
+
+        entities = [
+            NanoKVMBinarySensor(
+                coordinator=coordinator,
+                description=description,
+            )
+            for description in BINARY_SENSORS
+            if description.key not in network_entities_added
+            and description.should_create_fn(coordinator)
+        ]
+        if not entities:
+            return
+
+        async_add_entities(entities)
+        network_entities_added.update(entity.entity_description.key for entity in entities)
+
     entry.async_on_unload(
         async_dispatcher_connect(
             hass,
             SIGNAL_NEW_MEDIA_ENTITIES.format(entry.entry_id),
             async_add_media_binary_sensors,
+        )
+    )
+    entry.async_on_unload(
+        async_dispatcher_connect(
+            hass,
+            SIGNAL_NEW_NETWORK_ENTITIES.format(entry.entry_id),
+            async_add_network_binary_sensors,
         )
     )
 

--- a/custom_components/nanokvm/button.py
+++ b/custom_components/nanokvm/button.py
@@ -14,6 +14,7 @@ from nanokvm.models import GpioType, HWVersion
 
 from .const import (
     DOMAIN,
+    ICON_CLOCK,
     ICON_HID,
     ICON_KVM,
     ICON_POWER,
@@ -37,6 +38,11 @@ def _is_pcie_hardware(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
         coordinator.hardware_info
         and coordinator.hardware_info.version == HWVersion.PCIE
     )
+
+
+def _is_pro_hardware(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
+    """Return whether the device is Pro hardware."""
+    return coordinator.is_pro_hardware
 
 
 BUTTONS: tuple[NanoKVMButtonEntityDescription, ...] = (
@@ -77,6 +83,15 @@ BUTTONS: tuple[NanoKVMButtonEntityDescription, ...] = (
         icon=ICON_HID,
         entity_category=EntityCategory.CONFIG,
         press_fn=lambda coordinator: coordinator.client.reset_hid(),
+    ),
+    NanoKVMButtonEntityDescription(
+        key="sync_time",
+        name="Sync Time",
+        translation_key="sync_time",
+        icon=ICON_CLOCK,
+        entity_category=EntityCategory.CONFIG,
+        press_fn=lambda coordinator: coordinator.client.sync_time(),
+        available_fn=_is_pro_hardware,
     ),
 )
 

--- a/custom_components/nanokvm/camera_webrtc.py
+++ b/custom_components/nanokvm/camera_webrtc.py
@@ -184,7 +184,7 @@ class NanoKVMWebRTCManager:
                 )
 
             if pro_offer is None:
-                await self._async_send_legacy_offer(websocket, offer_sdp)
+                await self._async_send_non_pro_offer(websocket, offer_sdp)
             else:
                 await self._async_send_pro_offers(websocket, pro_offer)
 
@@ -201,10 +201,10 @@ class NanoKVMWebRTCManager:
                 f"Unable to establish NanoKVM WebRTC signaling: {err}"
             ) from err
 
-    async def _async_send_legacy_offer(
+    async def _async_send_non_pro_offer(
         self, websocket: aiohttp.ClientWebSocketResponse, offer_sdp: str
     ) -> None:
-        """Send the legacy NanoKVM single video offer."""
+        """Send the non-Pro NanoKVM single video offer."""
         offer_data = json.dumps({"type": "offer", "sdp": offer_sdp})
         await websocket.send_json({"event": "video-offer", "data": offer_data})
 
@@ -272,7 +272,7 @@ class NanoKVMWebRTCManager:
                 raw_data = payload.get("data")
                 data = self._decode_signal_data(raw_data)
                 if session.pro_offer is None:
-                    self._handle_legacy_event(event, data, send_message)
+                    self._handle_non_pro_event(event, data, send_message)
                 else:
                     await self._async_handle_pro_event(
                         session_id, event, data, raw_data, send_message
@@ -342,13 +342,13 @@ class NanoKVMWebRTCManager:
             return None
         return data
 
-    def _handle_legacy_event(
+    def _handle_non_pro_event(
         self,
         event: str,
         data: dict[str, object] | None,
         send_message: WebRTCSendMessage,
     ) -> None:
-        """Handle legacy NanoKVM WebRTC events."""
+        """Handle non-Pro NanoKVM WebRTC events."""
         if data is None:
             return
 
@@ -551,7 +551,7 @@ class NanoKVMWebRTCManager:
         session: _NanoKVMWebRTCSession,
         candidate: RTCIceCandidateInit,
     ) -> None:
-        """Send one frontend ICE candidate to legacy or Pro signaling."""
+        """Send one frontend ICE candidate to non-Pro or Pro signaling."""
         if session.pro_offer is None:
             await self._async_send_candidate(
                 session.websocket, "video-candidate", candidate

--- a/custom_components/nanokvm/const.py
+++ b/custom_components/nanokvm/const.py
@@ -23,6 +23,12 @@ SERVICE_RESET_HDMI = "reset_hdmi"
 SERVICE_RESET_HID = "reset_hid"
 SERVICE_WAKE_ON_LAN = "wake_on_lan"
 SERVICE_SET_MOUSE_JIGGLER = "set_mouse_jiggler"
+SERVICE_SCAN_WIFI = "scan_wifi"
+SERVICE_LIST_IMAGES = "list_images"
+SERVICE_IMAGE_DOWNLOAD_ENABLED = "is_image_download_enabled"
+SERVICE_GET_IMAGE_DOWNLOAD_STATUS = "get_image_download_status"
+SERVICE_LIST_CUSTOM_EDIDS = "list_custom_edids"
+SERVICE_SET_LED_STRIP = "set_led_strip"
 
 # Service attributes
 ATTR_BUTTON_TYPE = "button_type"
@@ -31,6 +37,10 @@ ATTR_TEXT = "text"
 ATTR_MAC = "mac"
 ATTR_ENABLED = "enabled"
 ATTR_MODE = "mode"
+ATTR_ON = "on"
+ATTR_BRIGHTNESS = "brightness"
+ATTR_HORIZONTAL_COUNT = "horizontal_count"
+ATTR_VERTICAL_COUNT = "vertical_count"
 
 # Button types
 BUTTON_TYPE_POWER = "power"
@@ -56,8 +66,17 @@ ICON_CDROM = "mdi:disc"
 ICON_MOUSE_JIGGLER = "mdi:mouse"
 ICON_HDMI = "mdi:video-input-hdmi"
 ICON_WATCHDOG = "mdi:shield-refresh"
+ICON_LED_STRIP = "mdi:led-strip-variant"
+ICON_CLOCK = "mdi:clock-outline"
 
 # Signals
 SIGNAL_NEW_SSH_SENSORS = "nanokvm_new_ssh_sensors_{}"
 SIGNAL_NEW_SSH_SWITCHES = "nanokvm_new_ssh_switches_{}"
 SIGNAL_NEW_MEDIA_ENTITIES = "nanokvm_new_media_entities_{}"
+SIGNAL_NEW_NETWORK_ENTITIES = "nanokvm_new_network_entities_{}"
+
+# NanoKVM Pro LED strip limits
+LED_BRIGHTNESS_MIN = 0
+LED_BRIGHTNESS_MAX = 100
+LED_BEAD_MIN = 1
+LED_BEAD_TOTAL_LIMIT = 150

--- a/custom_components/nanokvm/coordinator.py
+++ b/custom_components/nanokvm/coordinator.py
@@ -23,6 +23,7 @@ from nanokvm.client import (
     NanoKVMAuthenticationFailure,
     NanoKVMClient,
     NanoKVMError,
+    NanoKVMNotSupportedError,
 )
 from nanokvm.models import (
     GetCdRomRsp,
@@ -54,12 +55,22 @@ _APP_VERSION_REQUEST_TIMEOUT_SECONDS = 45
 _APP_VERSION_CACHE_SECONDS = 300
 _APP_VERSION_FAILURE_CACHE_SECONDS = 60
 _WATCHDOG_MIN_VERSION = AwesomeVersion("2.2.2")
+_INVALID_FILE_CONTENT_CODE = -2
+_INVALID_FILE_CONTENT_MESSAGE = "invalid file content"
 
 
 def _is_auth_failure(error: Exception) -> bool:
     """Return whether the exception represents invalid credentials."""
     return isinstance(error, NanoKVMAuthenticationFailure) or (
         isinstance(error, aiohttp.ClientResponseError) and error.status == 401
+    )
+
+
+def _is_invalid_file_content_error(error: NanoKVMApiError) -> bool:
+    """Return whether the API error is NanoKVM's optional-file missing response."""
+    return (
+        error.code == _INVALID_FILE_CONTENT_CODE
+        and error.msg == _INVALID_FILE_CONTENT_MESSAGE
     )
 
 
@@ -309,10 +320,30 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         """Run an optional endpoint call; return None when the device lacks it."""
         try:
             return await call()
+        except NanoKVMNotSupportedError as err:
+            _LOGGER.debug(
+                "NanoKVM endpoint %s is not supported on this device: %s",
+                endpoint,
+                err,
+            )
+            return None
         except aiohttp.ClientResponseError as err:
             if err.status != 404:
                 raise
             _LOGGER.debug("NanoKVM endpoint %s is not available on this device", endpoint)
+            return None
+
+    async def _fetch_oled_info(self):
+        """Fetch OLED state, treating NanoKVM Pro's missing OLED file as unavailable."""
+        try:
+            return await self.client.get_oled_info()
+        except NanoKVMApiError as err:
+            if not _is_invalid_file_content_error(err):
+                raise
+            _LOGGER.debug(
+                "NanoKVM endpoint /vm/oled returned %r; treating OLED as unavailable",
+                _INVALID_FILE_CONTENT_MESSAGE,
+            )
             return None
 
     async def _async_fetch_core_data(self) -> None:
@@ -330,7 +361,7 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         self.ssh_state = await self.client.get_ssh_state()
         self.mdns_state = await self.client.get_mdns_state()
         self.hid_mode = await self.client.get_hid_mode()
-        self.oled_info = await self.client.get_oled_info()
+        self.oled_info = await self._fetch_oled_info()
         self.wifi_status = await self.client.get_wifi_status()
         if self.supports_hdmi_endpoint:
             self.hdmi_state = await self._fetch_optional(

--- a/custom_components/nanokvm/coordinator.py
+++ b/custom_components/nanokvm/coordinator.py
@@ -8,7 +8,6 @@ import logging
 from typing import Any
 
 import aiohttp
-import async_timeout
 from awesomeversion import AwesomeVersion, AwesomeVersionException
 
 from homeassistant.config_entries import ConfigEntry
@@ -40,6 +39,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     SIGNAL_NEW_MEDIA_ENTITIES,
+    SIGNAL_NEW_NETWORK_ENTITIES,
     SIGNAL_NEW_SSH_SENSORS,
     SIGNAL_NEW_SSH_SWITCHES,
 )
@@ -105,6 +105,13 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         self.cdrom_status = None
         self.mouse_jiggler_state = None
         self.hdmi_state = None
+        self.hdmi_capture = None
+        self.hdmi_passthrough = None
+        self.low_power = None
+        self.led_strip = None
+        self.lcd_time_format = None
+        self.time_status = None
+        self.static_ip = None
         self.swap_size = None
         self.tailscale_status = None
         self.uptime = None
@@ -114,6 +121,7 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         self.storage_total = None
         self.storage_used_percent = None
         self.media_entities_created = False
+        self.network_entities_created: set[str] = set()
         self.ssh_sensors_created = False
         self.ssh_switches_created = False
         self.ssh_metrics_collector = None
@@ -205,11 +213,12 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_fetch_with_client(self) -> dict[str, Any]:
         """Fetch data using the current client instance."""
-        async with self.client, async_timeout.timeout(_UPDATE_TIMEOUT_SECONDS):
+        async with self.client, asyncio.timeout(_UPDATE_TIMEOUT_SECONDS):
             if not self.client.token:
                 await self.client.authenticate(self.username, self.password)
 
             await self._async_fetch_core_data()
+            self._async_maybe_create_network_entities()
             await self._async_fetch_storage_data()
             self._async_maybe_create_media_entities()
             await self._async_refresh_ssh_data()
@@ -327,6 +336,13 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
                 err,
             )
             return None
+        except NanoKVMApiError as err:
+            _LOGGER.debug(
+                "NanoKVM optional endpoint %s returned an API error: %s",
+                endpoint,
+                err,
+            )
+            return None
         except aiohttp.ClientResponseError as err:
             if err.status != 404:
                 raise
@@ -352,7 +368,7 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         self.hostname_info = await self.client.get_hostname()
         self.hardware_info = await self.client.get_hardware()
         self.gpio_info = await self.client.get_gpio()
-        if self.supports_legacy_virtual_device_controls:
+        if self.hardware_info is not None:
             self.virtual_device_info = await self._fetch_optional(
                 "/vm/device/virtual", self.client.get_virtual_device_status
             )
@@ -377,6 +393,45 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         else:
             self.swap_size = None
         self.tailscale_status = await self.client.get_tailscale_status()
+        await self._async_fetch_pro_data()
+
+    async def _async_fetch_pro_data(self) -> None:
+        """Fetch optional NanoKVM Pro state used by entities."""
+        if not self.is_pro_hardware:
+            self._clear_pro_data()
+            return
+
+        self.hdmi_capture = await self._fetch_optional(
+            "/vm/hdmi/capture", self.client.get_hdmi_capture
+        )
+        self.hdmi_passthrough = await self._fetch_optional(
+            "/vm/hdmi/passthrough", self.client.get_hdmi_passthrough
+        )
+        self.low_power = await self._fetch_optional(
+            "/vm/low-power", self.client.get_low_power
+        )
+        self.led_strip = await self._fetch_optional(
+            "/vm/ledstrip/get", self.client.get_led_strip
+        )
+        self.lcd_time_format = await self._fetch_optional(
+            "/vm/lcd/time/format", self.client.get_lcd_time_format
+        )
+        self.time_status = await self._fetch_optional(
+            "/vm/time/status", self.client.get_time_status
+        )
+        self.static_ip = await self._fetch_optional(
+            "/network/static-ip", self.client.get_static_ip
+        )
+
+    def _clear_pro_data(self) -> None:
+        """Clear NanoKVM Pro-only state."""
+        self.hdmi_capture = None
+        self.hdmi_passthrough = None
+        self.low_power = None
+        self.led_strip = None
+        self.lcd_time_format = None
+        self.time_status = None
+        self.static_ip = None
 
     def _async_schedule_app_version_refresh(self) -> None:
         """Refresh application version info outside the critical poll path."""
@@ -441,7 +496,9 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
                 _LOGGER.debug(
                     "Failed to get mounted image, retrieving default value: %s", err
                 )
-                self.mounted_image = GetMountedImageRsp(file="")
+                self.mounted_image = GetMountedImageRsp(
+                    file="", cdrom=False, read_only=False
+                )
 
             if self.supports_cdrom_endpoint:
                 try:
@@ -456,7 +513,9 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
             else:
                 self.cdrom_status = None
         else:
-            self.mounted_image = GetMountedImageRsp(file="")
+            self.mounted_image = GetMountedImageRsp(
+                file="", cdrom=False, read_only=False
+            )
             self.cdrom_status = (
                 GetCdRomRsp(cdrom=0) if self.supports_cdrom_endpoint else None
             )
@@ -485,6 +544,13 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
             "cdrom_status": self.cdrom_status,
             "mouse_jiggler_state": self.mouse_jiggler_state,
             "hdmi_state": self.hdmi_state,
+            "hdmi_capture": self.hdmi_capture,
+            "hdmi_passthrough": self.hdmi_passthrough,
+            "low_power": self.low_power,
+            "led_strip": self.led_strip,
+            "lcd_time_format": self.lcd_time_format,
+            "time_status": self.time_status,
+            "static_ip": self.static_ip,
             "swap_size": self.swap_size,
             "tailscale_status": self.tailscale_status,
             "hostname_info": self.hostname_info,
@@ -525,26 +591,34 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         )
 
     @property
-    def supports_legacy_virtual_device_controls(self) -> bool:
-        """Return whether legacy virtual network/disk controls apply."""
+    def supports_non_pro_virtual_device_controls(self) -> bool:
+        """Return whether non-Pro virtual network/disk controls apply."""
         return self.hardware_info is not None and not self.is_pro_hardware
 
     @property
     def supports_hdmi_endpoint(self) -> bool:
-        """Return whether the legacy HDMI endpoint should be queried."""
+        """Return whether the non-Pro HDMI endpoint should be queried."""
         return bool(
             self.hardware_info and self.hardware_info.version == HWVersion.PCIE
         )
 
     @property
     def supports_swap_size(self) -> bool:
-        """Return whether the legacy swap-size endpoint should be queried."""
+        """Return whether the non-Pro swap-size endpoint should be queried."""
         return self.hardware_info is not None and not self.is_pro_hardware
 
     @property
     def supports_cdrom_endpoint(self) -> bool:
-        """Return whether the legacy CD-ROM endpoint should be queried."""
+        """Return whether the non-Pro CD-ROM endpoint should be queried."""
         return self.hardware_info is not None and not self.is_pro_hardware
+
+    def _active_network_connection_types(self) -> set[str]:
+        """Return active network connection types reported by the NanoKVM."""
+        return {
+            address.type.casefold()
+            for address in self.device_info.ips
+            if address.addr
+        }
 
     async def async_ensure_ssh_metrics_collector(self) -> SSHMetricsCollector:
         """Return the active SSH collector, creating it when needed."""
@@ -564,6 +638,23 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
                 self.hass, SIGNAL_NEW_MEDIA_ENTITIES.format(self.config_entry.entry_id)
             )
             self.media_entities_created = True
+
+    def _async_maybe_create_network_entities(self) -> None:
+        """Signal when per-connection network entities should be created."""
+        for connection_type in self._active_network_connection_types():
+            if connection_type in self.network_entities_created:
+                continue
+
+            _LOGGER.debug(
+                "Network connection type %s present, signaling to create entities",
+                connection_type,
+            )
+            async_dispatcher_send(
+                self.hass,
+                SIGNAL_NEW_NETWORK_ENTITIES.format(self.config_entry.entry_id),
+                connection_type,
+            )
+            self.network_entities_created.add(connection_type)
 
     async def _async_update_ssh_data(self) -> None:
         """Fetch data via SSH."""

--- a/custom_components/nanokvm/led.py
+++ b/custom_components/nanokvm/led.py
@@ -1,0 +1,82 @@
+"""NanoKVM Pro LED strip helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from nanokvm.models import GetLedStripRsp
+
+from .const import (
+    LED_BEAD_MIN,
+    LED_BEAD_TOTAL_LIMIT,
+    LED_BRIGHTNESS_MAX,
+    LED_BRIGHTNESS_MIN,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LedStripConfig:
+    """Complete NanoKVM Pro LED strip configuration."""
+
+    on: bool
+    brightness: int
+    horizontal_count: int
+    vertical_count: int
+
+
+def max_horizontal_count(vertical_count: int) -> int:
+    """Return maximum horizontal bead count for a vertical bead count."""
+    return LED_BEAD_TOTAL_LIMIT - (2 * vertical_count)
+
+
+def max_vertical_count(horizontal_count: int) -> int:
+    """Return maximum vertical bead count for a horizontal bead count."""
+    return (LED_BEAD_TOTAL_LIMIT - horizontal_count) // 2
+
+
+def validate_led_strip_config(config: LedStripConfig) -> None:
+    """Validate NanoKVM Pro LED strip values."""
+    if not LED_BRIGHTNESS_MIN <= config.brightness <= LED_BRIGHTNESS_MAX:
+        raise ValueError(
+            f"LED brightness must be between {LED_BRIGHTNESS_MIN} and "
+            f"{LED_BRIGHTNESS_MAX}"
+        )
+
+    if config.horizontal_count < LED_BEAD_MIN:
+        raise ValueError(f"Horizontal LED beads must be at least {LED_BEAD_MIN}")
+
+    if config.vertical_count < LED_BEAD_MIN:
+        raise ValueError(f"Vertical LED beads must be at least {LED_BEAD_MIN}")
+
+    if config.horizontal_count + (2 * config.vertical_count) > LED_BEAD_TOTAL_LIMIT:
+        raise ValueError(
+            "LED bead counts must satisfy horizontal_count + "
+            f"(2 * vertical_count) <= {LED_BEAD_TOTAL_LIMIT}"
+        )
+
+
+def build_led_strip_config(
+    current: GetLedStripRsp | None,
+    *,
+    on: bool | None = None,
+    brightness: int | None = None,
+    horizontal_count: int | None = None,
+    vertical_count: int | None = None,
+) -> LedStripConfig:
+    """Build and validate a complete LED strip config from partial updates."""
+    if current is None:
+        raise ValueError("LED strip state is unavailable")
+
+    config = LedStripConfig(
+        on=current.on if on is None else on,
+        brightness=current.brightness if brightness is None else brightness,
+        horizontal_count=(
+            current.horizontal_count
+            if horizontal_count is None
+            else horizontal_count
+        ),
+        vertical_count=(
+            current.vertical_count if vertical_count is None else vertical_count
+        ),
+    )
+    validate_led_strip_config(config)
+    return config

--- a/custom_components/nanokvm/manifest.json
+++ b/custom_components/nanokvm/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Wouter0100/homeassistant-nanokvm/issues",
   "loggers": ["nanokvm"],
-  "requirements": ["nanokvm==1.0.0"],
-  "version": "2.0.0-beta2",
+  "requirements": ["nanokvm==1.2.0"],
+  "version": "2.0.0-beta3",
   "zeroconf": ["_workstation._tcp.local."]
 }

--- a/custom_components/nanokvm/number.py
+++ b/custom_components/nanokvm/number.py
@@ -1,0 +1,257 @@
+"""Number platform for Sipeed NanoKVM."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.components.number import (
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory, PERCENTAGE
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    DOMAIN,
+    ICON_LED_STRIP,
+    LED_BEAD_MIN,
+    LED_BEAD_TOTAL_LIMIT,
+    LED_BRIGHTNESS_MAX,
+    LED_BRIGHTNESS_MIN,
+)
+from .coordinator import NanoKVMDataUpdateCoordinator
+from .entity import NanoKVMEntity
+from .led import build_led_strip_config, max_horizontal_count, max_vertical_count
+
+
+@dataclass(frozen=True, kw_only=True)
+class NanoKVMNumberEntityDescription(NumberEntityDescription):
+    """Describes NanoKVM number entity."""
+
+    value_fn: Callable[[NanoKVMDataUpdateCoordinator], float | None] = lambda _: None
+    available_fn: Callable[[NanoKVMDataUpdateCoordinator], bool] = lambda _: True
+    min_value_fn: Callable[[NanoKVMDataUpdateCoordinator], float] = (
+        lambda _: LED_BEAD_MIN
+    )
+    max_value_fn: Callable[[NanoKVMDataUpdateCoordinator], float] = (
+        lambda _: LED_BEAD_TOTAL_LIMIT
+    )
+    set_value_fn: Callable[
+        [NanoKVMDataUpdateCoordinator, float], Awaitable[Any]
+    ] | None = None
+
+
+def _has_led_strip(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
+    """Return whether Pro LED strip state is available."""
+    return coordinator.is_pro_hardware and coordinator.led_strip is not None
+
+
+def _led_brightness_value(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> float | None:
+    """Return LED strip brightness."""
+    return coordinator.led_strip.brightness if coordinator.led_strip else None
+
+
+def _led_horizontal_value(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> float | None:
+    """Return horizontal LED bead count."""
+    return coordinator.led_strip.horizontal_count if coordinator.led_strip else None
+
+
+def _led_vertical_value(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> float | None:
+    """Return vertical LED bead count."""
+    return coordinator.led_strip.vertical_count if coordinator.led_strip else None
+
+
+def _led_horizontal_max(coordinator: NanoKVMDataUpdateCoordinator) -> float:
+    """Return maximum horizontal beads for the current vertical count."""
+    vertical_count = (
+        coordinator.led_strip.vertical_count
+        if coordinator.led_strip
+        else LED_BEAD_MIN
+    )
+    return max_horizontal_count(vertical_count)
+
+
+def _led_vertical_max(coordinator: NanoKVMDataUpdateCoordinator) -> float:
+    """Return maximum vertical beads for the current horizontal count."""
+    horizontal_count = (
+        coordinator.led_strip.horizontal_count
+        if coordinator.led_strip
+        else LED_BEAD_MIN
+    )
+    return max_vertical_count(horizontal_count)
+
+
+async def _set_led_brightness(
+    coordinator: NanoKVMDataUpdateCoordinator, value: float
+) -> None:
+    """Set LED strip brightness while preserving other LED settings."""
+    config = build_led_strip_config(coordinator.led_strip, brightness=int(value))
+    await coordinator.client.set_led_strip(
+        on=config.on,
+        brightness=config.brightness,
+        horizontal_count=config.horizontal_count,
+        vertical_count=config.vertical_count,
+    )
+
+
+async def _set_led_horizontal_count(
+    coordinator: NanoKVMDataUpdateCoordinator, value: float
+) -> None:
+    """Set horizontal LED bead count while preserving other LED settings."""
+    config = build_led_strip_config(coordinator.led_strip, horizontal_count=int(value))
+    await coordinator.client.set_led_strip(
+        on=config.on,
+        brightness=config.brightness,
+        horizontal_count=config.horizontal_count,
+        vertical_count=config.vertical_count,
+    )
+
+
+async def _set_led_vertical_count(
+    coordinator: NanoKVMDataUpdateCoordinator, value: float
+) -> None:
+    """Set vertical LED bead count while preserving other LED settings."""
+    config = build_led_strip_config(coordinator.led_strip, vertical_count=int(value))
+    await coordinator.client.set_led_strip(
+        on=config.on,
+        brightness=config.brightness,
+        horizontal_count=config.horizontal_count,
+        vertical_count=config.vertical_count,
+    )
+
+
+NUMBERS: tuple[NanoKVMNumberEntityDescription, ...] = (
+    NanoKVMNumberEntityDescription(
+        key="led_brightness",
+        name="LED Brightness",
+        translation_key="led_brightness",
+        icon=ICON_LED_STRIP,
+        entity_category=EntityCategory.CONFIG,
+        native_min_value=LED_BRIGHTNESS_MIN,
+        native_max_value=LED_BRIGHTNESS_MAX,
+        native_step=1,
+        native_unit_of_measurement=PERCENTAGE,
+        mode=NumberMode.SLIDER,
+        value_fn=_led_brightness_value,
+        available_fn=_has_led_strip,
+        min_value_fn=lambda _: LED_BRIGHTNESS_MIN,
+        max_value_fn=lambda _: LED_BRIGHTNESS_MAX,
+        set_value_fn=_set_led_brightness,
+    ),
+    NanoKVMNumberEntityDescription(
+        key="led_horizontal_beads",
+        name="LED Horizontal Beads",
+        translation_key="led_horizontal_beads",
+        icon=ICON_LED_STRIP,
+        entity_category=EntityCategory.CONFIG,
+        native_min_value=LED_BEAD_MIN,
+        native_max_value=LED_BEAD_TOTAL_LIMIT - 2,
+        native_step=1,
+        mode=NumberMode.BOX,
+        value_fn=_led_horizontal_value,
+        available_fn=_has_led_strip,
+        min_value_fn=lambda _: LED_BEAD_MIN,
+        max_value_fn=_led_horizontal_max,
+        set_value_fn=_set_led_horizontal_count,
+    ),
+    NanoKVMNumberEntityDescription(
+        key="led_vertical_beads",
+        name="LED Vertical Beads",
+        translation_key="led_vertical_beads",
+        icon=ICON_LED_STRIP,
+        entity_category=EntityCategory.CONFIG,
+        native_min_value=LED_BEAD_MIN,
+        native_max_value=(LED_BEAD_TOTAL_LIMIT - 1) // 2,
+        native_step=1,
+        mode=NumberMode.BOX,
+        value_fn=_led_vertical_value,
+        available_fn=_has_led_strip,
+        min_value_fn=lambda _: LED_BEAD_MIN,
+        max_value_fn=_led_vertical_max,
+        set_value_fn=_set_led_vertical_count,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up NanoKVM number based on a config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_entities(
+        NanoKVMNumber(
+            coordinator=coordinator,
+            description=description,
+        )
+        for description in NUMBERS
+        if description.available_fn(coordinator)
+    )
+
+
+class NanoKVMNumber(NanoKVMEntity, NumberEntity):
+    """Defines a NanoKVM number."""
+
+    entity_description: NanoKVMNumberEntityDescription
+
+    def __init__(
+        self,
+        coordinator: NanoKVMDataUpdateCoordinator,
+        description: NanoKVMNumberEntityDescription,
+    ) -> None:
+        """Initialize NanoKVM number."""
+        self.entity_description = description
+        super().__init__(
+            coordinator=coordinator,
+            unique_id_suffix=f"number_{description.key}",
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self.entity_description.available_fn(
+            self.coordinator
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the number value."""
+        return self.entity_description.value_fn(self.coordinator)
+
+    @property
+    def native_min_value(self) -> float:
+        """Return the dynamic minimum value."""
+        return self.entity_description.min_value_fn(self.coordinator)
+
+    @property
+    def native_max_value(self) -> float:
+        """Return the dynamic maximum value."""
+        return self.entity_description.max_value_fn(self.coordinator)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the number value."""
+        if self.entity_description.set_value_fn is None:
+            raise RuntimeError(
+                f"Missing number handler for number: {self.entity_description.key}"
+            )
+
+        try:
+            async with self.coordinator.client:
+                await self.entity_description.set_value_fn(self.coordinator, value)
+        except ValueError as err:
+            raise HomeAssistantError(str(err)) from err
+
+        await self.coordinator.async_request_refresh()

--- a/custom_components/nanokvm/select.py
+++ b/custom_components/nanokvm/select.py
@@ -11,7 +11,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from nanokvm.models import HidMode, MouseJigglerMode
+from nanokvm.models import DiskType, HidMode, LcdTimeFormat, MouseJigglerMode, VirtualDevice
 
 from .const import (
     DOMAIN,
@@ -28,8 +28,9 @@ from .entity import NanoKVMEntity
 class NanoKVMSelectEntityDescription(SelectEntityDescription):
     """Describes NanoKVM select entity."""
 
-    value_fn: Callable[[NanoKVMDataUpdateCoordinator], str] = lambda _: ""
+    value_fn: Callable[[NanoKVMDataUpdateCoordinator], str | None] = lambda _: ""
     available_fn: Callable[[NanoKVMDataUpdateCoordinator], bool] = lambda _: True
+    options_fn: Callable[[NanoKVMDataUpdateCoordinator], list[str]] | None = None
     select_option_fn: Callable[
         [NanoKVMDataUpdateCoordinator, str], Awaitable[Any]
     ] | None = None
@@ -69,6 +70,16 @@ SWAP_OPTIONS = {
 }
 SWAP_VALUES = {v: k for k, v in SWAP_OPTIONS.items()}
 
+LCD_TIME_FORMAT_OPTIONS = {
+    "12h": LcdTimeFormat.TWELVE_HOUR,
+    "24h": LcdTimeFormat.TWENTY_FOUR_HOUR,
+}
+
+DISK_TYPE_OPTIONS = {
+    "emmc": DiskType.EMMC,
+    "sdcard": DiskType.SDCARD,
+}
+
 
 def _has_hid_mode(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
     """Return whether HID mode information is available."""
@@ -88,6 +99,29 @@ def _has_oled(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
 def _has_swap_size(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
     """Return whether swap size information is available."""
     return coordinator.swap_size is not None
+
+
+def _has_lcd_time_format(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
+    """Return whether LCD time format is available."""
+    return coordinator.is_pro_hardware and coordinator.lcd_time_format is not None
+
+
+def _pro_disk_options(coordinator: NanoKVMDataUpdateCoordinator) -> list[str]:
+    """Return available Pro virtual disk type options."""
+    if coordinator.virtual_device_info is None:
+        return []
+
+    options: list[str] = []
+    if coordinator.virtual_device_info.is_emmc_exist:
+        options.append(DiskType.EMMC.value)
+    if coordinator.virtual_device_info.is_sd_card_exist:
+        options.append(DiskType.SDCARD.value)
+    return options
+
+
+def _has_pro_disk_options(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
+    """Return whether Pro virtual disk type options are available."""
+    return coordinator.is_pro_hardware and bool(_pro_disk_options(coordinator))
 
 
 def _hid_mode_value(coordinator: NanoKVMDataUpdateCoordinator) -> str:
@@ -149,6 +183,43 @@ def _set_swap_size(
     return coordinator.client.set_swap_size(SWAP_OPTIONS.get(option, 0))
 
 
+def _lcd_time_format_value(coordinator: NanoKVMDataUpdateCoordinator) -> str | None:
+    """Return current LCD time format."""
+    if coordinator.lcd_time_format is None:
+        return None
+    return coordinator.lcd_time_format.format.value
+
+
+def _set_lcd_time_format(
+    coordinator: NanoKVMDataUpdateCoordinator, option: str
+) -> Awaitable[Any]:
+    """Set LCD time format from option key."""
+    return coordinator.client.set_lcd_time_format(
+        LCD_TIME_FORMAT_OPTIONS.get(option, LcdTimeFormat.TWENTY_FOUR_HOUR)
+    )
+
+
+def _pro_disk_value(coordinator: NanoKVMDataUpdateCoordinator) -> str | None:
+    """Return current Pro virtual disk type."""
+    if coordinator.virtual_device_info is None:
+        return None
+
+    mounted_disk = coordinator.virtual_device_info.mounted_disk
+    if mounted_disk not in _pro_disk_options(coordinator):
+        return None
+    return mounted_disk
+
+
+def _set_pro_disk(
+    coordinator: NanoKVMDataUpdateCoordinator, option: str
+) -> Awaitable[Any]:
+    """Set Pro virtual disk type."""
+    return coordinator.client.update_virtual_device(
+        VirtualDevice.DISK,
+        disk_type=DISK_TYPE_OPTIONS.get(option, DiskType.EMMC),
+    )
+
+
 SELECTS: tuple[NanoKVMSelectEntityDescription, ...] = (
     NanoKVMSelectEntityDescription(
         key="hid_mode",
@@ -194,6 +265,29 @@ SELECTS: tuple[NanoKVMSelectEntityDescription, ...] = (
         select_option_fn=_set_swap_size,
         available_fn=_has_swap_size,
     ),
+    NanoKVMSelectEntityDescription(
+        key="lcd_time_format",
+        name="LCD Time Format",
+        translation_key="lcd_time_format",
+        icon="mdi:clock-digital",
+        entity_category=EntityCategory.CONFIG,
+        options=list(LCD_TIME_FORMAT_OPTIONS.keys()),
+        value_fn=_lcd_time_format_value,
+        select_option_fn=_set_lcd_time_format,
+        available_fn=_has_lcd_time_format,
+    ),
+    NanoKVMSelectEntityDescription(
+        key="virtual_disk_type",
+        name="Virtual Disk Type",
+        translation_key="virtual_disk_type",
+        icon=ICON_DISK,
+        entity_category=EntityCategory.CONFIG,
+        options=list(DISK_TYPE_OPTIONS.keys()),
+        options_fn=_pro_disk_options,
+        value_fn=_pro_disk_value,
+        select_option_fn=_set_pro_disk,
+        available_fn=_has_pro_disk_options,
+    ),
 )
 
 
@@ -233,9 +327,16 @@ class NanoKVMSelect(NanoKVMEntity, SelectEntity):
         )
 
     @property
-    def current_option(self) -> str:
+    def current_option(self) -> str | None:
         """Return the current selected option."""
         return self.entity_description.value_fn(self.coordinator)
+
+    @property
+    def options(self) -> list[str]:
+        """Return selectable options."""
+        if self.entity_description.options_fn is not None:
+            return self.entity_description.options_fn(self.coordinator)
+        return self.entity_description.options
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""

--- a/custom_components/nanokvm/sensor.py
+++ b/custom_components/nanokvm/sensor.py
@@ -25,6 +25,7 @@ from .const import (
     ICON_IMAGE,
     ICON_NETWORK,
     SIGNAL_NEW_MEDIA_ENTITIES,
+    SIGNAL_NEW_NETWORK_ENTITIES,
     ICON_SSH,
     SIGNAL_NEW_SSH_SENSORS,
 )
@@ -84,6 +85,61 @@ def _ip_address_attributes(coordinator: NanoKVMDataUpdateCoordinator) -> dict[st
     }
 
 
+def _addresses_for_connection_type(
+    coordinator: NanoKVMDataUpdateCoordinator, connection_type: str
+) -> list[Any]:
+    """Return NanoKVM addresses for a connection type."""
+    return [
+        address
+        for address in coordinator.device_info.ips
+        if address.type.casefold() == connection_type
+    ]
+
+
+def _has_connection_type(
+    coordinator: NanoKVMDataUpdateCoordinator, connection_type: str
+) -> bool:
+    """Return whether an IP connection type is active."""
+    return any(
+        address.addr
+        for address in _addresses_for_connection_type(coordinator, connection_type)
+    )
+
+
+def _connection_ip_value(
+    coordinator: NanoKVMDataUpdateCoordinator, connection_type: str
+) -> str | None:
+    """Return preferred IP address for a connection type."""
+    addresses = _addresses_for_connection_type(coordinator, connection_type)
+    if not addresses:
+        return None
+
+    for address in addresses:
+        if address.version == "IPv4":
+            return address.addr
+
+    return addresses[0].addr
+
+
+def _connection_ip_attributes(
+    coordinator: NanoKVMDataUpdateCoordinator, connection_type: str
+) -> dict[str, Any]:
+    """Return reported addresses for a connection type."""
+    return {
+        "addresses": [
+            {
+                "name": address.name,
+                "addr": address.addr,
+                "version": address.version,
+                "type": address.type,
+            }
+            for address in _addresses_for_connection_type(
+                coordinator, connection_type
+            )
+        ]
+    }
+
+
 def _tailscale_state_value(coordinator: NanoKVMDataUpdateCoordinator) -> str | None:
     """Return normalized tailscale state value."""
     if coordinator.tailscale_status is None:
@@ -121,6 +177,7 @@ class NanoKVMSensorEntityDescription(SensorEntityDescription):
     available_fn: Callable[[NanoKVMDataUpdateCoordinator], bool] = lambda _: True
     should_create_fn: Callable[[NanoKVMDataUpdateCoordinator], bool] = lambda _: True
     attributes_fn: Callable[[NanoKVMDataUpdateCoordinator], dict[str, Any]] = lambda _: {}
+    connection_type: str | None = None
 
 
 MEDIA_SENSORS: tuple[NanoKVMSensorEntityDescription, ...] = (
@@ -155,6 +212,41 @@ SENSORS: tuple[NanoKVMSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=_tailscale_state_value,
         attributes_fn=_tailscale_attributes,
+    ),
+)
+
+NETWORK_SENSORS: tuple[NanoKVMSensorEntityDescription, ...] = (
+    NanoKVMSensorEntityDescription(
+        key="wired_ip_address",
+        name="Wired IP Address",
+        translation_key="wired_ip_address",
+        icon=ICON_NETWORK,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        connection_type="wired",
+        value_fn=lambda coordinator: _connection_ip_value(coordinator, "wired"),
+        available_fn=lambda coordinator: _has_connection_type(coordinator, "wired"),
+        should_create_fn=lambda coordinator: _has_connection_type(
+            coordinator, "wired"
+        ),
+        attributes_fn=lambda coordinator: _connection_ip_attributes(
+            coordinator, "wired"
+        ),
+    ),
+    NanoKVMSensorEntityDescription(
+        key="wireless_ip_address",
+        name="Wireless IP Address",
+        translation_key="wireless_ip_address",
+        icon="mdi:wifi",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        connection_type="wireless",
+        value_fn=lambda coordinator: _connection_ip_value(coordinator, "wireless"),
+        available_fn=lambda coordinator: _has_connection_type(coordinator, "wireless"),
+        should_create_fn=lambda coordinator: _has_connection_type(
+            coordinator, "wireless"
+        ),
+        attributes_fn=lambda coordinator: _connection_ip_attributes(
+            coordinator, "wireless"
+        ),
     ),
 )
 
@@ -221,9 +313,34 @@ async def async_setup_entry(
             coordinator=coordinator,
             description=description,
         )
-        for description in SENSORS
+        for description in (*SENSORS, *NETWORK_SENSORS)
         if description.should_create_fn(coordinator)
     )
+
+    network_sensor_keys_added = {
+        description.key
+        for description in NETWORK_SENSORS
+        if description.should_create_fn(coordinator)
+    }
+
+    @callback
+    def async_add_network_sensors(connection_type: str) -> None:
+        """Add per-connection IP sensors when a connection type appears."""
+        entities = [
+            NanoKVMSensor(
+                coordinator=coordinator,
+                description=description,
+            )
+            for description in NETWORK_SENSORS
+            if description.connection_type == connection_type
+            and description.key not in network_sensor_keys_added
+            and description.should_create_fn(coordinator)
+        ]
+        if not entities:
+            return
+
+        async_add_entities(entities)
+        network_sensor_keys_added.update(entity.entity_description.key for entity in entities)
 
     media_entities_added = False
 
@@ -279,6 +396,13 @@ async def async_setup_entry(
     entry.async_on_unload(
         async_dispatcher_connect(
             hass, SIGNAL_NEW_MEDIA_ENTITIES.format(entry.entry_id), async_add_media_sensors
+        )
+    )
+    entry.async_on_unload(
+        async_dispatcher_connect(
+            hass,
+            SIGNAL_NEW_NETWORK_ENTITIES.format(entry.entry_id),
+            async_add_network_sensors,
         )
     )
     entry.async_on_unload(

--- a/custom_components/nanokvm/services.py
+++ b/custom_components/nanokvm/services.py
@@ -3,10 +3,16 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable, Callable
+from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+)
 from homeassistant.exceptions import HomeAssistantError
 
 from nanokvm.client import NanoKVMClient
@@ -14,24 +20,39 @@ from nanokvm.models import GpioType, MouseJigglerMode
 
 from .const import (
     ATTR_BUTTON_TYPE,
+    ATTR_BRIGHTNESS,
     ATTR_DURATION,
     ATTR_ENABLED,
+    ATTR_HORIZONTAL_COUNT,
     ATTR_MAC,
     ATTR_MODE,
+    ATTR_ON,
     ATTR_TEXT,
+    ATTR_VERTICAL_COUNT,
     BUTTON_TYPE_POWER,
     BUTTON_TYPE_RESET,
     CONF_HOST,
     DOMAIN,
+    LED_BEAD_MIN,
+    LED_BEAD_TOTAL_LIMIT,
+    LED_BRIGHTNESS_MAX,
+    LED_BRIGHTNESS_MIN,
+    SERVICE_GET_IMAGE_DOWNLOAD_STATUS,
+    SERVICE_IMAGE_DOWNLOAD_ENABLED,
+    SERVICE_LIST_CUSTOM_EDIDS,
+    SERVICE_LIST_IMAGES,
     SERVICE_PASTE_TEXT,
     SERVICE_PUSH_BUTTON,
     SERVICE_REBOOT,
     SERVICE_RESET_HDMI,
     SERVICE_RESET_HID,
+    SERVICE_SCAN_WIFI,
+    SERVICE_SET_LED_STRIP,
     SERVICE_SET_MOUSE_JIGGLER,
     SERVICE_WAKE_ON_LAN,
 )
 from .coordinator import NanoKVMDataUpdateCoordinator
+from .led import build_led_strip_config
 from .utils import host_match_key
 
 _LOGGER = logging.getLogger(__name__)
@@ -44,6 +65,12 @@ _SERVICE_NAMES = (
     SERVICE_RESET_HID,
     SERVICE_WAKE_ON_LAN,
     SERVICE_SET_MOUSE_JIGGLER,
+    SERVICE_SET_LED_STRIP,
+    SERVICE_SCAN_WIFI,
+    SERVICE_LIST_IMAGES,
+    SERVICE_IMAGE_DOWNLOAD_ENABLED,
+    SERVICE_GET_IMAGE_DOWNLOAD_STATUS,
+    SERVICE_LIST_CUSTOM_EDIDS,
 )
 
 _OPTIONAL_HOST_FIELD = {
@@ -81,6 +108,42 @@ SET_MOUSE_JIGGLER_SCHEMA = vol.Schema(
 )
 
 HOST_ONLY_SCHEMA = vol.Schema(_OPTIONAL_HOST_FIELD)
+
+SET_LED_STRIP_SCHEMA = vol.Schema(
+    _OPTIONAL_HOST_FIELD
+    | {
+        vol.Optional(ATTR_ON): bool,
+        vol.Optional(ATTR_BRIGHTNESS): vol.All(
+            vol.Coerce(int),
+            vol.Range(min=LED_BRIGHTNESS_MIN, max=LED_BRIGHTNESS_MAX),
+        ),
+        vol.Optional(ATTR_HORIZONTAL_COUNT): vol.All(
+            vol.Coerce(int),
+            vol.Range(min=LED_BEAD_MIN, max=LED_BEAD_TOTAL_LIMIT),
+        ),
+        vol.Optional(ATTR_VERTICAL_COUNT): vol.All(
+            vol.Coerce(int),
+            vol.Range(min=LED_BEAD_MIN, max=LED_BEAD_TOTAL_LIMIT),
+        ),
+    }
+)
+
+
+def _model_to_response(value: Any) -> ServiceResponse:
+    """Convert pydantic responses into Home Assistant service responses."""
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if isinstance(value, dict):
+        return value
+    return {"value": value}
+
+
+def _ensure_pro(coordinator: NanoKVMDataUpdateCoordinator, service_name: str) -> None:
+    """Raise when a service requires NanoKVM Pro hardware."""
+    if not coordinator.is_pro_hardware:
+        raise HomeAssistantError(
+            f"The {service_name} service is only available for NanoKVM Pro devices"
+        )
 
 
 def async_register_services(hass: HomeAssistant) -> None:
@@ -123,7 +186,9 @@ def async_register_services(hass: HomeAssistant) -> None:
     async def _execute_service(
         call: ServiceCall,
         service_name: str,
-        handler: Callable[[NanoKVMClient, str], Awaitable[None]],
+        handler: Callable[
+            [NanoKVMDataUpdateCoordinator, NanoKVMClient, str], Awaitable[None]
+        ],
     ) -> None:
         """Execute a service on the targeted NanoKVM device."""
         coordinator = _resolve_target_coordinator(call)
@@ -132,7 +197,34 @@ def async_register_services(hass: HomeAssistant) -> None:
 
         try:
             async with client:
-                await handler(client, host)
+                await handler(coordinator, client, host)
+        except HomeAssistantError:
+            raise
+        except Exception as err:
+            _LOGGER.error(
+                "Error executing %s service for %s: %s", service_name, host, err
+            )
+            raise HomeAssistantError(
+                f"Failed to execute {service_name} for {host}: {err}"
+            ) from err
+
+    async def _execute_response_service(
+        call: ServiceCall,
+        service_name: str,
+        handler: Callable[
+            [NanoKVMDataUpdateCoordinator, NanoKVMClient, str], Awaitable[Any]
+        ],
+    ) -> ServiceResponse:
+        """Execute a response-returning service on the targeted NanoKVM device."""
+        coordinator = _resolve_target_coordinator(call)
+        client = coordinator.client
+        host = coordinator.config_entry.data.get(CONF_HOST, "<unknown>")
+
+        try:
+            async with client:
+                return _model_to_response(await handler(coordinator, client, host))
+        except HomeAssistantError:
+            raise
         except Exception as err:
             _LOGGER.error(
                 "Error executing %s service for %s: %s", service_name, host, err
@@ -147,7 +239,11 @@ def async_register_services(hass: HomeAssistant) -> None:
         duration = call.data[ATTR_DURATION]
         gpio_type = GpioType.POWER if button_type == BUTTON_TYPE_POWER else GpioType.RESET
 
-        async def service_logic(client: NanoKVMClient, host: str) -> None:
+        async def service_logic(
+            coordinator: NanoKVMDataUpdateCoordinator,
+            client: NanoKVMClient,
+            host: str,
+        ) -> None:
             await client.push_button(gpio_type, duration)
             _LOGGER.debug("Button %s pushed for %d ms on %s", button_type, duration, host)
 
@@ -157,7 +253,11 @@ def async_register_services(hass: HomeAssistant) -> None:
         """Handle the paste text service."""
         text = call.data[ATTR_TEXT]
 
-        async def service_logic(client: NanoKVMClient, host: str) -> None:
+        async def service_logic(
+            coordinator: NanoKVMDataUpdateCoordinator,
+            client: NanoKVMClient,
+            host: str,
+        ) -> None:
             await client.paste_text(text)
             _LOGGER.debug("Text pasted on %s", host)
 
@@ -166,7 +266,11 @@ def async_register_services(hass: HomeAssistant) -> None:
     async def handle_reboot(call: ServiceCall) -> None:
         """Handle the reboot service."""
 
-        async def service_logic(client: NanoKVMClient, host: str) -> None:
+        async def service_logic(
+            coordinator: NanoKVMDataUpdateCoordinator,
+            client: NanoKVMClient,
+            host: str,
+        ) -> None:
             await client.reboot_system()
             _LOGGER.debug("System reboot initiated on %s", host)
 
@@ -175,7 +279,11 @@ def async_register_services(hass: HomeAssistant) -> None:
     async def handle_reset_hdmi(call: ServiceCall) -> None:
         """Handle the reset HDMI service."""
 
-        async def service_logic(client: NanoKVMClient, host: str) -> None:
+        async def service_logic(
+            coordinator: NanoKVMDataUpdateCoordinator,
+            client: NanoKVMClient,
+            host: str,
+        ) -> None:
             await client.reset_hdmi()
             _LOGGER.debug("HDMI reset initiated on %s", host)
 
@@ -184,7 +292,11 @@ def async_register_services(hass: HomeAssistant) -> None:
     async def handle_reset_hid(call: ServiceCall) -> None:
         """Handle the reset HID service."""
 
-        async def service_logic(client: NanoKVMClient, host: str) -> None:
+        async def service_logic(
+            coordinator: NanoKVMDataUpdateCoordinator,
+            client: NanoKVMClient,
+            host: str,
+        ) -> None:
             await client.reset_hid()
             _LOGGER.debug("HID reset initiated on %s", host)
 
@@ -194,7 +306,11 @@ def async_register_services(hass: HomeAssistant) -> None:
         """Handle the wake on LAN service."""
         mac = call.data[ATTR_MAC]
 
-        async def service_logic(client: NanoKVMClient, host: str) -> None:
+        async def service_logic(
+            coordinator: NanoKVMDataUpdateCoordinator,
+            client: NanoKVMClient,
+            host: str,
+        ) -> None:
             await client.send_wake_on_lan(mac)
             _LOGGER.debug("Wake on LAN packet sent to %s via %s", mac, host)
 
@@ -210,13 +326,134 @@ def async_register_services(hass: HomeAssistant) -> None:
             else MouseJigglerMode.RELATIVE
         )
 
-        async def service_logic(client: NanoKVMClient, host: str) -> None:
+        async def service_logic(
+            coordinator: NanoKVMDataUpdateCoordinator,
+            client: NanoKVMClient,
+            host: str,
+        ) -> None:
             await client.set_mouse_jiggler_state(enabled, mode)
             _LOGGER.debug(
                 "Mouse jiggler on %s set to %s with mode %s", host, enabled, mode_str
             )
 
         await _execute_service(call, SERVICE_SET_MOUSE_JIGGLER, service_logic)
+
+    async def handle_set_led_strip(call: ServiceCall) -> None:
+        """Handle the set LED strip service."""
+        if not any(
+            field in call.data
+            for field in (
+                ATTR_ON,
+                ATTR_BRIGHTNESS,
+                ATTR_HORIZONTAL_COUNT,
+                ATTR_VERTICAL_COUNT,
+            )
+        ):
+            raise HomeAssistantError("At least one LED strip field is required")
+
+        async def service_logic(
+            coordinator: NanoKVMDataUpdateCoordinator,
+            client: NanoKVMClient,
+            host: str,
+        ) -> None:
+            _ensure_pro(coordinator, SERVICE_SET_LED_STRIP)
+            try:
+                config = build_led_strip_config(
+                    coordinator.led_strip,
+                    on=call.data.get(ATTR_ON),
+                    brightness=call.data.get(ATTR_BRIGHTNESS),
+                    horizontal_count=call.data.get(ATTR_HORIZONTAL_COUNT),
+                    vertical_count=call.data.get(ATTR_VERTICAL_COUNT),
+                )
+            except ValueError as err:
+                raise HomeAssistantError(str(err)) from err
+
+            await client.set_led_strip(
+                on=config.on,
+                brightness=config.brightness,
+                horizontal_count=config.horizontal_count,
+                vertical_count=config.vertical_count,
+            )
+            _LOGGER.debug("LED strip settings updated on %s", host)
+
+        await _execute_service(call, SERVICE_SET_LED_STRIP, service_logic)
+        await _resolve_target_coordinator(call).async_request_refresh()
+
+    async def handle_scan_wifi(call: ServiceCall) -> ServiceResponse:
+        """Handle the scan Wi-Fi response service."""
+
+        async def service_logic(
+            coordinator: NanoKVMDataUpdateCoordinator,
+            client: NanoKVMClient,
+            host: str,
+        ) -> Any:
+            _ensure_pro(coordinator, SERVICE_SCAN_WIFI)
+            return await client.scan_wifi()
+
+        return await _execute_response_service(call, SERVICE_SCAN_WIFI, service_logic)
+
+    async def handle_list_images(call: ServiceCall) -> ServiceResponse:
+        """Handle the list images response service."""
+
+        async def service_logic(
+            coordinator: NanoKVMDataUpdateCoordinator,
+            client: NanoKVMClient,
+            host: str,
+        ) -> Any:
+            return await client.get_images()
+
+        return await _execute_response_service(call, SERVICE_LIST_IMAGES, service_logic)
+
+    async def handle_image_download_enabled(call: ServiceCall) -> ServiceResponse:
+        """Handle the image download enabled response service."""
+
+        async def service_logic(
+            coordinator: NanoKVMDataUpdateCoordinator,
+            client: NanoKVMClient,
+            host: str,
+        ) -> Any:
+            return await client.is_image_download_enabled()
+
+        return await _execute_response_service(
+            call,
+            SERVICE_IMAGE_DOWNLOAD_ENABLED,
+            service_logic,
+        )
+
+    async def handle_get_image_download_status(
+        call: ServiceCall,
+    ) -> ServiceResponse:
+        """Handle the image download status response service."""
+
+        async def service_logic(
+            coordinator: NanoKVMDataUpdateCoordinator,
+            client: NanoKVMClient,
+            host: str,
+        ) -> Any:
+            return await client.get_image_download_status()
+
+        return await _execute_response_service(
+            call,
+            SERVICE_GET_IMAGE_DOWNLOAD_STATUS,
+            service_logic,
+        )
+
+    async def handle_list_custom_edids(call: ServiceCall) -> ServiceResponse:
+        """Handle the list custom EDIDs response service."""
+
+        async def service_logic(
+            coordinator: NanoKVMDataUpdateCoordinator,
+            client: NanoKVMClient,
+            host: str,
+        ) -> Any:
+            _ensure_pro(coordinator, SERVICE_LIST_CUSTOM_EDIDS)
+            return await client.get_custom_edid_list()
+
+        return await _execute_response_service(
+            call,
+            SERVICE_LIST_CUSTOM_EDIDS,
+            service_logic,
+        )
 
     hass.services.async_register(
         DOMAIN, SERVICE_PUSH_BUTTON, handle_push_button, schema=PUSH_BUTTON_SCHEMA
@@ -241,6 +478,47 @@ def async_register_services(hass: HomeAssistant) -> None:
         SERVICE_SET_MOUSE_JIGGLER,
         handle_set_mouse_jiggler,
         schema=SET_MOUSE_JIGGLER_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_LED_STRIP,
+        handle_set_led_strip,
+        schema=SET_LED_STRIP_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SCAN_WIFI,
+        handle_scan_wifi,
+        schema=HOST_ONLY_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_LIST_IMAGES,
+        handle_list_images,
+        schema=HOST_ONLY_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_IMAGE_DOWNLOAD_ENABLED,
+        handle_image_download_enabled,
+        schema=HOST_ONLY_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GET_IMAGE_DOWNLOAD_STATUS,
+        handle_get_image_download_status,
+        schema=HOST_ONLY_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_LIST_CUSTOM_EDIDS,
+        handle_list_custom_edids,
+        schema=HOST_ONLY_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
     )
 
 

--- a/custom_components/nanokvm/services.yaml
+++ b/custom_components/nanokvm/services.yaml
@@ -114,3 +114,93 @@ set_mouse_jiggler:
           options:
             - "absolute"
             - "relative"
+
+set_led_strip:
+  name: Set LED Strip
+  description: Configure NanoKVM Pro LED strip settings.
+  fields:
+    host:
+      name: Host
+      description: Optional target host. Required when multiple NanoKVM devices are configured.
+      selector:
+        text:
+    on:
+      name: On
+      description: Enable or disable the LED strip.
+      selector:
+        boolean:
+    brightness:
+      name: Brightness
+      description: LED strip brightness percentage.
+      selector:
+        number:
+          min: 0
+          max: 100
+          mode: slider
+          unit_of_measurement: "%"
+    horizontal_count:
+      name: Horizontal Beads
+      description: Horizontal LED bead count.
+      selector:
+        number:
+          min: 1
+          max: 148
+          mode: box
+    vertical_count:
+      name: Vertical Beads
+      description: Vertical LED bead count.
+      selector:
+        number:
+          min: 1
+          max: 74
+          mode: box
+
+scan_wifi:
+  name: Scan Wi-Fi
+  description: Scan nearby Wi-Fi networks and return the NanoKVM Pro response.
+  fields:
+    host:
+      name: Host
+      description: Optional target host. Required when multiple NanoKVM devices are configured.
+      selector:
+        text:
+
+list_images:
+  name: List Images
+  description: List images available on the NanoKVM.
+  fields:
+    host:
+      name: Host
+      description: Optional target host. Required when multiple NanoKVM devices are configured.
+      selector:
+        text:
+
+is_image_download_enabled:
+  name: Is Image Download Enabled
+  description: Return whether image downloading is enabled on the NanoKVM.
+  fields:
+    host:
+      name: Host
+      description: Optional target host. Required when multiple NanoKVM devices are configured.
+      selector:
+        text:
+
+get_image_download_status:
+  name: Get Image Download Status
+  description: Return the current NanoKVM image download status.
+  fields:
+    host:
+      name: Host
+      description: Optional target host. Required when multiple NanoKVM devices are configured.
+      selector:
+        text:
+
+list_custom_edids:
+  name: List Custom EDIDs
+  description: List custom EDIDs available on a NanoKVM Pro.
+  fields:
+    host:
+      name: Host
+      description: Optional target host. Required when multiple NanoKVM devices are configured.
+      selector:
+        text:

--- a/custom_components/nanokvm/services.yaml
+++ b/custom_components/nanokvm/services.yaml
@@ -124,8 +124,8 @@ set_led_strip:
       description: Optional target host. Required when multiple NanoKVM devices are configured.
       selector:
         text:
-    on:
-      name: On
+    "on":
+      name: "On"
       description: Enable or disable the LED strip.
       selector:
         boolean:

--- a/custom_components/nanokvm/strings.json
+++ b/custom_components/nanokvm/strings.json
@@ -43,5 +43,163 @@
       "unknown": "Unexpected error",
       "ssl_certificate_changed": "The SSL certificate has changed"
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "wired_connected": {
+        "name": "Wired Connected"
+      },
+      "static_ip_enabled": {
+        "name": "Static IP Enabled"
+      },
+      "time_synchronized": {
+        "name": "Time Synchronized"
+      }
+    },
+    "sensor": {
+      "wired_ip_address": {
+        "name": "Wired IP Address",
+        "state_attributes": {
+          "addresses": {
+            "name": "Addresses"
+          }
+        }
+      },
+      "wireless_ip_address": {
+        "name": "Wireless IP Address",
+        "state_attributes": {
+          "addresses": {
+            "name": "Addresses"
+          }
+        }
+      }
+    },
+    "switch": {
+      "hdmi_capture": {
+        "name": "HDMI Capture"
+      },
+      "hdmi_passthrough": {
+        "name": "HDMI Passthrough"
+      },
+      "low_power": {
+        "name": "Low Power"
+      },
+      "led_strip": {
+        "name": "LED Strip"
+      },
+      "virtual_mic": {
+        "name": "Virtual Microphone"
+      }
+    },
+    "select": {
+      "lcd_time_format": {
+        "name": "LCD Time Format",
+        "state": {
+          "12h": "12-hour",
+          "24h": "24-hour"
+        }
+      },
+      "virtual_disk_type": {
+        "name": "Virtual Disk Type",
+        "state": {
+          "emmc": "eMMC",
+          "sdcard": "SD Card"
+        }
+      }
+    },
+    "number": {
+      "led_brightness": {
+        "name": "LED Brightness"
+      },
+      "led_horizontal_beads": {
+        "name": "LED Horizontal Beads"
+      },
+      "led_vertical_beads": {
+        "name": "LED Vertical Beads"
+      }
+    },
+    "button": {
+      "sync_time": {
+        "name": "Sync Time"
+      }
+    }
+  },
+  "services": {
+    "set_led_strip": {
+      "name": "Set LED Strip",
+      "description": "Configure NanoKVM Pro LED strip settings.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Optional target host. Required when multiple NanoKVM devices are configured."
+        },
+        "on": {
+          "name": "On",
+          "description": "Enable or disable the LED strip."
+        },
+        "brightness": {
+          "name": "Brightness",
+          "description": "LED strip brightness percentage."
+        },
+        "horizontal_count": {
+          "name": "Horizontal Beads",
+          "description": "Horizontal LED bead count."
+        },
+        "vertical_count": {
+          "name": "Vertical Beads",
+          "description": "Vertical LED bead count."
+        }
+      }
+    },
+    "scan_wifi": {
+      "name": "Scan Wi-Fi",
+      "description": "Scan nearby Wi-Fi networks and return the NanoKVM Pro response.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Optional target host. Required when multiple NanoKVM devices are configured."
+        }
+      }
+    },
+    "list_images": {
+      "name": "List Images",
+      "description": "List images available on the NanoKVM.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Optional target host. Required when multiple NanoKVM devices are configured."
+        }
+      }
+    },
+    "is_image_download_enabled": {
+      "name": "Is Image Download Enabled",
+      "description": "Return whether image downloading is enabled on the NanoKVM.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Optional target host. Required when multiple NanoKVM devices are configured."
+        }
+      }
+    },
+    "get_image_download_status": {
+      "name": "Get Image Download Status",
+      "description": "Return the current NanoKVM image download status.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Optional target host. Required when multiple NanoKVM devices are configured."
+        }
+      }
+    },
+    "list_custom_edids": {
+      "name": "List Custom EDIDs",
+      "description": "List custom EDIDs available on a NanoKVM Pro.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Optional target host. Required when multiple NanoKVM devices are configured."
+        }
+      }
+    }
   }
 }

--- a/custom_components/nanokvm/switch.py
+++ b/custom_components/nanokvm/switch.py
@@ -11,6 +11,7 @@ from homeassistant.components.switch import SwitchEntity, SwitchEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -20,6 +21,7 @@ from .const import (
     DOMAIN,
     ICON_DISK,
     ICON_HDMI,
+    ICON_LED_STRIP,
     ICON_MDNS,
     ICON_NETWORK,
     ICON_SSH,
@@ -29,6 +31,7 @@ from .const import (
 )
 from .coordinator import NanoKVMDataUpdateCoordinator
 from .entity import NanoKVMEntity
+from .led import build_led_strip_config
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -66,9 +69,65 @@ def _watchdog_available(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
     return coordinator.supports_watchdog and coordinator.watchdog_enabled is not None
 
 
-def _virtual_device_available(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
-    """Return whether the legacy virtual-device switches apply to this device."""
-    return coordinator.supports_legacy_virtual_device_controls
+def _non_pro_virtual_device_available(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
+    """Return whether the non-Pro virtual-device switches apply to this device."""
+    return coordinator.supports_non_pro_virtual_device_controls
+
+
+def _pro_virtual_device_available(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
+    """Return whether Pro virtual-device controls are available."""
+    return coordinator.is_pro_hardware and coordinator.virtual_device_info is not None
+
+
+def _pro_virtual_mic_available(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
+    """Return whether Pro virtual microphone control is available."""
+    return (
+        _pro_virtual_device_available(coordinator)
+        and coordinator.virtual_device_info is not None
+        and coordinator.virtual_device_info.mic is not None
+    )
+
+
+def _hdmi_capture_available(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
+    """Return whether Pro HDMI capture control is available."""
+    return coordinator.is_pro_hardware and coordinator.hdmi_capture is not None
+
+
+def _hdmi_passthrough_available(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
+    """Return whether Pro HDMI passthrough control is available."""
+    return coordinator.is_pro_hardware and coordinator.hdmi_passthrough is not None
+
+
+def _low_power_available(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
+    """Return whether Pro low-power mode control is available."""
+    return coordinator.is_pro_hardware and coordinator.low_power is not None
+
+
+def _led_strip_available(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
+    """Return whether Pro LED strip control is available."""
+    return coordinator.is_pro_hardware and coordinator.led_strip is not None
+
+
+def _led_strip_value(coordinator: NanoKVMDataUpdateCoordinator) -> bool:
+    """Return LED strip state."""
+    return bool(coordinator.led_strip and coordinator.led_strip.on)
+
+
+async def _set_led_strip_on(
+    coordinator: NanoKVMDataUpdateCoordinator, enabled: bool
+) -> None:
+    """Set LED strip power while preserving other LED settings."""
+    try:
+        config = build_led_strip_config(coordinator.led_strip, on=enabled)
+    except ValueError as err:
+        raise HomeAssistantError(str(err)) from err
+
+    await coordinator.client.set_led_strip(
+        on=config.on,
+        brightness=config.brightness,
+        horizontal_count=config.horizontal_count,
+        vertical_count=config.vertical_count,
+    )
 
 
 SWITCHES: tuple[NanoKVMSwitchEntityDescription, ...] = (
@@ -105,7 +164,7 @@ SWITCHES: tuple[NanoKVMSwitchEntityDescription, ...] = (
         value_fn=lambda coordinator: bool(
             coordinator.virtual_device_info and coordinator.virtual_device_info.network
         ),
-        available_fn=_virtual_device_available,
+        available_fn=_non_pro_virtual_device_available,
         virtual_device=VirtualDevice.NETWORK,
     ),
     NanoKVMSwitchEntityDescription(
@@ -117,8 +176,32 @@ SWITCHES: tuple[NanoKVMSwitchEntityDescription, ...] = (
         value_fn=lambda coordinator: bool(
             coordinator.virtual_device_info and coordinator.virtual_device_info.disk
         ),
-        available_fn=_virtual_device_available,
+        available_fn=_non_pro_virtual_device_available,
         virtual_device=VirtualDevice.DISK,
+    ),
+    NanoKVMSwitchEntityDescription(
+        key="virtual_network",
+        name="Virtual Network",
+        translation_key="virtual_network",
+        icon=ICON_NETWORK,
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda coordinator: bool(
+            coordinator.virtual_device_info and coordinator.virtual_device_info.network
+        ),
+        available_fn=_pro_virtual_device_available,
+        virtual_device=VirtualDevice.NETWORK,
+    ),
+    NanoKVMSwitchEntityDescription(
+        key="virtual_mic",
+        name="Virtual Microphone",
+        translation_key="virtual_mic",
+        icon="mdi:microphone",
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda coordinator: bool(
+            coordinator.virtual_device_info and coordinator.virtual_device_info.mic
+        ),
+        available_fn=_pro_virtual_mic_available,
+        virtual_device=VirtualDevice.MIC,
     ),
     NanoKVMSwitchEntityDescription(
         key="power",
@@ -141,6 +224,56 @@ SWITCHES: tuple[NanoKVMSwitchEntityDescription, ...] = (
         turn_on_fn=lambda coordinator: coordinator.client.enable_hdmi(),
         turn_off_fn=lambda coordinator: coordinator.client.disable_hdmi(),
         available_fn=_hdmi_available,
+    ),
+    NanoKVMSwitchEntityDescription(
+        key="hdmi_capture",
+        name="HDMI Capture",
+        translation_key="hdmi_capture",
+        icon=ICON_HDMI,
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda coordinator: bool(
+            coordinator.hdmi_capture and coordinator.hdmi_capture.enabled
+        ),
+        turn_on_fn=lambda coordinator: coordinator.client.set_hdmi_capture(True),
+        turn_off_fn=lambda coordinator: coordinator.client.set_hdmi_capture(False),
+        available_fn=_hdmi_capture_available,
+    ),
+    NanoKVMSwitchEntityDescription(
+        key="hdmi_passthrough",
+        name="HDMI Passthrough",
+        translation_key="hdmi_passthrough",
+        icon=ICON_HDMI,
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda coordinator: bool(
+            coordinator.hdmi_passthrough and coordinator.hdmi_passthrough.enabled
+        ),
+        turn_on_fn=lambda coordinator: coordinator.client.set_hdmi_passthrough(True),
+        turn_off_fn=lambda coordinator: coordinator.client.set_hdmi_passthrough(False),
+        available_fn=_hdmi_passthrough_available,
+    ),
+    NanoKVMSwitchEntityDescription(
+        key="low_power",
+        name="Low Power",
+        translation_key="low_power",
+        icon="mdi:power-sleep",
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda coordinator: bool(
+            coordinator.low_power and coordinator.low_power.enabled
+        ),
+        turn_on_fn=lambda coordinator: coordinator.client.set_low_power(True),
+        turn_off_fn=lambda coordinator: coordinator.client.set_low_power(False),
+        available_fn=_low_power_available,
+    ),
+    NanoKVMSwitchEntityDescription(
+        key="led_strip",
+        name="LED Strip",
+        translation_key="led_strip",
+        icon=ICON_LED_STRIP,
+        entity_category=EntityCategory.CONFIG,
+        value_fn=_led_strip_value,
+        turn_on_fn=lambda coordinator: _set_led_strip_on(coordinator, True),
+        turn_off_fn=lambda coordinator: _set_led_strip_on(coordinator, False),
+        available_fn=_led_strip_available,
     ),
 )
 
@@ -165,7 +298,7 @@ async def async_setup_entry(
     """Set up NanoKVM switch based on a config entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
-    entities = []
+    entities: list[NanoKVMSwitch] = []
     for description in SWITCHES:
         if not description.available_fn(coordinator):
             continue

--- a/custom_components/nanokvm/translations/en.json
+++ b/custom_components/nanokvm/translations/en.json
@@ -73,11 +73,20 @@
       "wifi_connected": {
         "name": "WiFi Connected"
       },
+      "wired_connected": {
+        "name": "Wired Connected"
+      },
       "cdrom_mode": {
         "name": "CD-ROM Mode"
       },
       "mouse_jiggler": {
         "name": "Mouse Jiggler"
+      },
+      "static_ip_enabled": {
+        "name": "Static IP Enabled"
+      },
+      "time_synchronized": {
+        "name": "Time Synchronized"
       }
     },
     "sensor": {
@@ -95,6 +104,22 @@
       },
       "ip_address": {
         "name": "IP Address",
+        "state_attributes": {
+          "addresses": {
+            "name": "Addresses"
+          }
+        }
+      },
+      "wired_ip_address": {
+        "name": "Wired IP Address",
+        "state_attributes": {
+          "addresses": {
+            "name": "Addresses"
+          }
+        }
+      },
+      "wireless_ip_address": {
+        "name": "Wireless IP Address",
         "state_attributes": {
           "addresses": {
             "name": "Addresses"
@@ -167,6 +192,21 @@
       "hdmi": {
         "name": "HDMI Output"
       },
+      "hdmi_capture": {
+        "name": "HDMI Capture"
+      },
+      "hdmi_passthrough": {
+        "name": "HDMI Passthrough"
+      },
+      "low_power": {
+        "name": "Low Power"
+      },
+      "led_strip": {
+        "name": "LED Strip"
+      },
+      "virtual_mic": {
+        "name": "Virtual Microphone"
+      },
       "watchdog": {
         "name": "Watchdog"
       }
@@ -210,6 +250,31 @@
           "256_mb": "256 MB",
           "512_mb": "512 MB"
         }
+      },
+      "lcd_time_format": {
+        "name": "LCD Time Format",
+        "state": {
+          "12h": "12-hour",
+          "24h": "24-hour"
+        }
+      },
+      "virtual_disk_type": {
+        "name": "Virtual Disk Type",
+        "state": {
+          "emmc": "eMMC",
+          "sdcard": "SD Card"
+        }
+      }
+    },
+    "number": {
+      "led_brightness": {
+        "name": "LED Brightness"
+      },
+      "led_horizontal_beads": {
+        "name": "LED Horizontal Beads"
+      },
+      "led_vertical_beads": {
+        "name": "LED Vertical Beads"
       }
     },
     "update": {
@@ -232,6 +297,9 @@
       },
       "reset_hid": {
         "name": "Reset HID"
+      },
+      "sync_time": {
+        "name": "Sync Time"
       }
     },
     "camera": {
@@ -332,6 +400,82 @@
         "mode": {
           "name": "Mode",
           "description": "The mouse jiggler mode (absolute or relative)."
+        }
+      }
+    },
+    "set_led_strip": {
+      "name": "Set LED Strip",
+      "description": "Configure NanoKVM Pro LED strip settings.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Optional target host. Required when multiple NanoKVM devices are configured."
+        },
+        "on": {
+          "name": "On",
+          "description": "Enable or disable the LED strip."
+        },
+        "brightness": {
+          "name": "Brightness",
+          "description": "LED strip brightness percentage."
+        },
+        "horizontal_count": {
+          "name": "Horizontal Beads",
+          "description": "Horizontal LED bead count."
+        },
+        "vertical_count": {
+          "name": "Vertical Beads",
+          "description": "Vertical LED bead count."
+        }
+      }
+    },
+    "scan_wifi": {
+      "name": "Scan Wi-Fi",
+      "description": "Scan nearby Wi-Fi networks and return the NanoKVM Pro response.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Optional target host. Required when multiple NanoKVM devices are configured."
+        }
+      }
+    },
+    "list_images": {
+      "name": "List Images",
+      "description": "List images available on the NanoKVM.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Optional target host. Required when multiple NanoKVM devices are configured."
+        }
+      }
+    },
+    "is_image_download_enabled": {
+      "name": "Is Image Download Enabled",
+      "description": "Return whether image downloading is enabled on the NanoKVM.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Optional target host. Required when multiple NanoKVM devices are configured."
+        }
+      }
+    },
+    "get_image_download_status": {
+      "name": "Get Image Download Status",
+      "description": "Return the current NanoKVM image download status.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Optional target host. Required when multiple NanoKVM devices are configured."
+        }
+      }
+    },
+    "list_custom_edids": {
+      "name": "List Custom EDIDs",
+      "description": "List custom EDIDs available on a NanoKVM Pro.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Optional target host. Required when multiple NanoKVM devices are configured."
         }
       }
     }

--- a/custom_components/nanokvm/translations/fr.json
+++ b/custom_components/nanokvm/translations/fr.json
@@ -73,11 +73,20 @@
       "wifi_connected": {
         "name": "WiFi connecté"
       },
+      "wired_connected": {
+        "name": "Connexion filaire active"
+      },
       "cdrom_mode": {
         "name": "Mode CD-ROM"
       },
       "mouse_jiggler": {
         "name": "Agitateur de souris"
+      },
+      "static_ip_enabled": {
+        "name": "IP statique activée"
+      },
+      "time_synchronized": {
+        "name": "Heure synchronisée"
       }
     },
     "sensor": {
@@ -95,6 +104,22 @@
       },
       "ip_address": {
         "name": "Adresse IP",
+        "state_attributes": {
+          "addresses": {
+            "name": "Adresses"
+          }
+        }
+      },
+      "wired_ip_address": {
+        "name": "Adresse IP filaire",
+        "state_attributes": {
+          "addresses": {
+            "name": "Adresses"
+          }
+        }
+      },
+      "wireless_ip_address": {
+        "name": "Adresse IP sans fil",
         "state_attributes": {
           "addresses": {
             "name": "Adresses"
@@ -167,6 +192,21 @@
       "hdmi": {
         "name": "Sortie HDMI"
       },
+      "hdmi_capture": {
+        "name": "Capture HDMI"
+      },
+      "hdmi_passthrough": {
+        "name": "Pass-through HDMI"
+      },
+      "low_power": {
+        "name": "Basse consommation"
+      },
+      "led_strip": {
+        "name": "Bande LED"
+      },
+      "virtual_mic": {
+        "name": "Microphone virtuel"
+      },
       "watchdog": {
         "name": "Watchdog"
       }
@@ -210,11 +250,31 @@
           "256_mb": "256 Mo",
           "512_mb": "512 Mo"
         }
+      },
+      "lcd_time_format": {
+        "name": "Format horaire LCD",
+        "state": {
+          "12h": "12 heures",
+          "24h": "24 heures"
+        }
+      },
+      "virtual_disk_type": {
+        "name": "Type de disque virtuel",
+        "state": {
+          "emmc": "eMMC",
+          "sdcard": "Carte SD"
+        }
       }
     },
-    "update": {
-      "application": {
-        "name": "Application"
+    "number": {
+      "led_brightness": {
+        "name": "LED Luminosité"
+      },
+      "led_horizontal_beads": {
+        "name": "LED perles horizontales"
+      },
+      "led_vertical_beads": {
+        "name": "LED perles verticales"
       }
     },
     "button": {
@@ -232,6 +292,14 @@
       },
       "reset_hid": {
         "name": "Réinitialiser HID"
+      },
+      "sync_time": {
+        "name": "Synchroniser l'heure"
+      }
+    },
+    "update": {
+      "application": {
+        "name": "Application"
       }
     },
     "camera": {
@@ -332,6 +400,82 @@
         "mode": {
           "name": "Mode",
           "description": "Le mode de l'agitateur de souris (absolu ou relatif)."
+        }
+      }
+    },
+    "set_led_strip": {
+      "name": "Définir la bande LED",
+      "description": "Configurer les paramètres de la bande LED du NanoKVM Pro.",
+      "fields": {
+        "host": {
+          "name": "Hôte",
+          "description": "Hôte cible facultatif. Obligatoire lorsque plusieurs appareils NanoKVM sont configurés."
+        },
+        "on": {
+          "name": "Activé",
+          "description": "Activer ou désactiver la bande LED."
+        },
+        "brightness": {
+          "name": "Luminosité",
+          "description": "Pourcentage de luminosité de la bande LED."
+        },
+        "horizontal_count": {
+          "name": "Perles horizontales",
+          "description": "Nombre de perles LED horizontales."
+        },
+        "vertical_count": {
+          "name": "Perles verticales",
+          "description": "Nombre de perles LED verticales."
+        }
+      }
+    },
+    "scan_wifi": {
+      "name": "Scanner le Wi-Fi",
+      "description": "Rechercher les réseaux Wi-Fi à proximité et retourner la réponse du NanoKVM Pro.",
+      "fields": {
+        "host": {
+          "name": "Hôte",
+          "description": "Hôte cible facultatif. Obligatoire lorsque plusieurs appareils NanoKVM sont configurés."
+        }
+      }
+    },
+    "list_images": {
+      "name": "Lister les images",
+      "description": "Lister les images disponibles sur le NanoKVM.",
+      "fields": {
+        "host": {
+          "name": "Hôte",
+          "description": "Hôte cible facultatif. Obligatoire lorsque plusieurs appareils NanoKVM sont configurés."
+        }
+      }
+    },
+    "is_image_download_enabled": {
+      "name": "Téléchargement d'images activé",
+      "description": "Retourner si le téléchargement d'images est activé sur le NanoKVM.",
+      "fields": {
+        "host": {
+          "name": "Hôte",
+          "description": "Hôte cible facultatif. Obligatoire lorsque plusieurs appareils NanoKVM sont configurés."
+        }
+      }
+    },
+    "get_image_download_status": {
+      "name": "Obtenir l'état du téléchargement d'image",
+      "description": "Retourner l'état actuel du téléchargement d'image du NanoKVM.",
+      "fields": {
+        "host": {
+          "name": "Hôte",
+          "description": "Hôte cible facultatif. Obligatoire lorsque plusieurs appareils NanoKVM sont configurés."
+        }
+      }
+    },
+    "list_custom_edids": {
+      "name": "Lister les EDID personnalisés",
+      "description": "Lister les EDID personnalisés disponibles sur un NanoKVM Pro.",
+      "fields": {
+        "host": {
+          "name": "Hôte",
+          "description": "Hôte cible facultatif. Obligatoire lorsque plusieurs appareils NanoKVM sont configurés."
         }
       }
     }

--- a/custom_components/nanokvm/translations/pt-BR.json
+++ b/custom_components/nanokvm/translations/pt-BR.json
@@ -73,11 +73,20 @@
       "wifi_connected": {
         "name": "Wi-Fi Conectado"
       },
+      "wired_connected": {
+        "name": "Rede Cabeada Conectada"
+      },
       "cdrom_mode": {
         "name": "Modo CD-ROM"
       },
       "mouse_jiggler": {
         "name": "Mouse Jiggler"
+      },
+      "static_ip_enabled": {
+        "name": "IP Estático Ativado"
+      },
+      "time_synchronized": {
+        "name": "Hora Sincronizada"
       }
     },
     "sensor": {
@@ -95,6 +104,22 @@
       },
       "ip_address": {
         "name": "Endereço IP",
+        "state_attributes": {
+          "addresses": {
+            "name": "Endereços"
+          }
+        }
+      },
+      "wired_ip_address": {
+        "name": "Endereço IP Cabeado",
+        "state_attributes": {
+          "addresses": {
+            "name": "Endereços"
+          }
+        }
+      },
+      "wireless_ip_address": {
+        "name": "Endereço IP Sem Fio",
         "state_attributes": {
           "addresses": {
             "name": "Endereços"
@@ -167,6 +192,21 @@
       "hdmi": {
         "name": "Saída HDMI"
       },
+      "hdmi_capture": {
+        "name": "Captura HDMI"
+      },
+      "hdmi_passthrough": {
+        "name": "Pass-through HDMI"
+      },
+      "low_power": {
+        "name": "Baixo Consumo"
+      },
+      "led_strip": {
+        "name": "Fita LED"
+      },
+      "virtual_mic": {
+        "name": "Microfone Virtual"
+      },
       "watchdog": {
         "name": "Watchdog"
       }
@@ -210,11 +250,31 @@
           "256_mb": "256 MB",
           "512_mb": "512 MB"
         }
+      },
+      "lcd_time_format": {
+        "name": "Formato de Hora do LCD",
+        "state": {
+          "12h": "12 horas",
+          "24h": "24 horas"
+        }
+      },
+      "virtual_disk_type": {
+        "name": "Tipo de Disco Virtual",
+        "state": {
+          "emmc": "eMMC",
+          "sdcard": "Cartão SD"
+        }
       }
     },
-    "update": {
-      "application": {
-        "name": "Aplicativo"
+    "number": {
+      "led_brightness": {
+        "name": "LED Brilho"
+      },
+      "led_horizontal_beads": {
+        "name": "LED Pontos Horizontais"
+      },
+      "led_vertical_beads": {
+        "name": "LED Pontos Verticais"
       }
     },
     "button": {
@@ -232,6 +292,14 @@
       },
       "reset_hid": {
         "name": "Resetar HID"
+      },
+      "sync_time": {
+        "name": "Sincronizar Hora"
+      }
+    },
+    "update": {
+      "application": {
+        "name": "Aplicativo"
       }
     },
     "camera": {
@@ -332,6 +400,82 @@
         "mode": {
           "name": "Modo",
           "description": "O modo do mouse jiggler (absoluto ou relativo)."
+        }
+      }
+    },
+    "set_led_strip": {
+      "name": "Definir Fita LED",
+      "description": "Configura as opções da fita LED do NanoKVM Pro.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Host de destino opcional. Obrigatório quando vários dispositivos NanoKVM estiverem configurados."
+        },
+        "on": {
+          "name": "Ligada",
+          "description": "Liga ou desliga a fita LED."
+        },
+        "brightness": {
+          "name": "Brilho",
+          "description": "Percentual de brilho da fita LED."
+        },
+        "horizontal_count": {
+          "name": "Pontos Horizontais",
+          "description": "Quantidade de pontos LED horizontais."
+        },
+        "vertical_count": {
+          "name": "Pontos Verticais",
+          "description": "Quantidade de pontos LED verticais."
+        }
+      }
+    },
+    "scan_wifi": {
+      "name": "Escanear Wi-Fi",
+      "description": "Escaneia redes Wi-Fi próximas e retorna a resposta do NanoKVM Pro.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Host de destino opcional. Obrigatório quando vários dispositivos NanoKVM estiverem configurados."
+        }
+      }
+    },
+    "list_images": {
+      "name": "Listar Imagens",
+      "description": "Lista as imagens disponíveis no NanoKVM.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Host de destino opcional. Obrigatório quando vários dispositivos NanoKVM estiverem configurados."
+        }
+      }
+    },
+    "is_image_download_enabled": {
+      "name": "Download de Imagem Ativado",
+      "description": "Retorna se o download de imagens está ativado no NanoKVM.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Host de destino opcional. Obrigatório quando vários dispositivos NanoKVM estiverem configurados."
+        }
+      }
+    },
+    "get_image_download_status": {
+      "name": "Obter Status do Download de Imagem",
+      "description": "Retorna o status atual do download de imagem do NanoKVM.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Host de destino opcional. Obrigatório quando vários dispositivos NanoKVM estiverem configurados."
+        }
+      }
+    },
+    "list_custom_edids": {
+      "name": "Listar EDIDs Personalizados",
+      "description": "Lista EDIDs personalizados disponíveis em um NanoKVM Pro.",
+      "fields": {
+        "host": {
+          "name": "Host",
+          "description": "Host de destino opcional. Obrigatório quando vários dispositivos NanoKVM estiverem configurados."
         }
       }
     }


### PR DESCRIPTION
## Summary

Beta 3 builds on beta 2's NanoKVM Pro WebRTC stability work and expands Pro support using `nanokvm==1.2.0`.

### Highlights

- Added NanoKVM Pro entities for HDMI capture/passthrough, low power, LED strip controls, virtual mic/network, virtual disk type, LCD time format, sync time, static IP enabled, and time synchronized state.
- Added LED strip controls with brightness and bead-count validation.
- Added wired and wireless IP diagnostic sensors.
- Added safe response services for Wi-Fi scan, image listing/download status, and custom EDID listing.
- Kept non-Pro-only endpoints properly gated.
- Updated English, French, and Brazilian Portuguese translations.
- Updated README, services docs, contributing notes, and agent docs.

This is still a beta release focused on stabilizing Pro support before expanding into more advanced/admin Pro APIs.
