### PR TITLE
Fix power switch and coordinator lifecycle handling

### DIFF
--- a/custom_components/nanokvm/__init__.py
+++ b/custom_components/nanokvm/__init__.py
@@ -118,9 +118,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return False
 
     domain_data = hass.data.get(DOMAIN, {})
-    coordinator = domain_data.pop(entry.entry_id, None)
-    if coordinator:
-        await coordinator.async_shutdown()
+    domain_data.pop(entry.entry_id, None)
 
     if not domain_data:
         async_unregister_services(hass)

--- a/custom_components/nanokvm/coordinator.py
+++ b/custom_components/nanokvm/coordinator.py
@@ -82,6 +82,8 @@ def _format_timeout_error(action: str) -> str:
 class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching NanoKVM data."""
 
+    config_entry: ConfigEntry
+
     def __init__(
         self,
         hass: HomeAssistant,
@@ -92,7 +94,6 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         device_info: GetInfoRsp,
     ) -> None:
         """Initialize the coordinator."""
-        self.config_entry = config_entry
         self.client = client
         self.username = username
         self.password = password
@@ -138,6 +139,7 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         super().__init__(
             hass,
             _LOGGER,
+            config_entry=config_entry,
             name=DOMAIN,
             update_interval=datetime.timedelta(seconds=DEFAULT_SCAN_INTERVAL),
         )
@@ -726,12 +728,16 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def async_shutdown(self) -> None:
         """Release any background tasks and live connections owned by the coordinator."""
-        if self._app_version_fetch_task is not None:
-            self._app_version_fetch_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._app_version_fetch_task
-            self._app_version_fetch_task = None
-
-        if self.ssh_metrics_collector:
-            await self.ssh_metrics_collector.disconnect()
-            self.ssh_metrics_collector = None
+        try:
+            await super().async_shutdown()
+        finally:
+            try:
+                if self._app_version_fetch_task is not None:
+                    self._app_version_fetch_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await self._app_version_fetch_task
+                    self._app_version_fetch_task = None
+            finally:
+                if self.ssh_metrics_collector:
+                    await self.ssh_metrics_collector.disconnect()
+                    self.ssh_metrics_collector = None

--- a/custom_components/nanokvm/switch.py
+++ b/custom_components/nanokvm/switch.py
@@ -413,10 +413,20 @@ class NanoKVMSwitch(NanoKVMEntity, SwitchEntity):
 class NanoKVMPowerSwitch(NanoKVMSwitch):
     """Defines a NanoKVM power switch with special shutdown behavior."""
 
+    async def _async_current_power_state(self) -> bool | None:
+        """Refresh and return the current power state when available."""
+        await self.coordinator.async_request_refresh()
+        if self.coordinator.gpio_info is None:
+            return None
+        return bool(self.coordinator.gpio_info.pwr)
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
+        del kwargs
         if self.entity_description.turn_on_fn is None:
             raise RuntimeError(f"Missing turn_on handler for switch: {self.entity_description.key}")
+        if await self._async_current_power_state() is True:
+            return
         async with self.coordinator.client:
             await self.entity_description.turn_on_fn(self.coordinator)
         await asyncio.sleep(1)
@@ -424,8 +434,11 @@ class NanoKVMPowerSwitch(NanoKVMSwitch):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the power switch with monitoring for actual shutdown."""
+        del kwargs
         if self.entity_description.turn_off_fn is None:
             raise RuntimeError(f"Missing turn_off handler for switch: {self.entity_description.key}")
+        if await self._async_current_power_state() is False:
+            return
         async with self.coordinator.client:
             await self.entity_description.turn_off_fn(self.coordinator)
 

--- a/tests/test_power_and_lifecycle.py
+++ b/tests/test_power_and_lifecycle.py
@@ -1,0 +1,136 @@
+"""Regression tests for NanoKVM power and coordinator lifecycle behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.config_entries import ConfigEntry
+
+from custom_components.nanokvm import async_unload_entry
+from custom_components.nanokvm.const import DOMAIN
+from custom_components.nanokvm.coordinator import NanoKVMDataUpdateCoordinator
+from custom_components.nanokvm.switch import (
+    SWITCHES,
+    NanoKVMPowerSwitch,
+    NanoKVMSwitchEntityDescription,
+)
+
+
+class FakeClient:
+    """Minimal async context-managed NanoKVM client for power tests."""
+
+    def __init__(self) -> None:
+        self.enter_count = 0
+        self.push_button = AsyncMock()
+
+    async def __aenter__(self) -> FakeClient:
+        """Enter the fake client context."""
+        self.enter_count += 1
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        """Exit the fake client context."""
+
+
+def _power_description() -> NanoKVMSwitchEntityDescription:
+    """Return the power switch description."""
+    return next(description for description in SWITCHES if description.key == "power")
+
+
+def _power_switch(power_state: bool) -> tuple[NanoKVMPowerSwitch, SimpleNamespace]:
+    """Create a power switch backed by a minimal coordinator."""
+    coordinator = SimpleNamespace(
+        async_request_refresh=AsyncMock(),
+        client=FakeClient(),
+        device_info=SimpleNamespace(device_key="test-device"),
+        gpio_info=SimpleNamespace(pwr=power_state),
+    )
+    return NanoKVMPowerSwitch(coordinator, _power_description()), coordinator
+
+
+def test_power_turn_on_is_noop_when_already_on() -> None:
+    """Turning on an already-on host must not press the momentary power button."""
+    switch, coordinator = _power_switch(True)
+
+    asyncio.run(switch.async_turn_on())
+
+    coordinator.async_request_refresh.assert_awaited_once_with()
+    assert coordinator.client.enter_count == 0
+    coordinator.client.push_button.assert_not_awaited()
+
+
+def test_power_turn_off_is_noop_when_already_off() -> None:
+    """Turning off an already-off host must not press the momentary power button."""
+    switch, coordinator = _power_switch(False)
+
+    asyncio.run(switch.async_turn_off())
+
+    coordinator.async_request_refresh.assert_awaited_once_with()
+    assert coordinator.client.enter_count == 0
+    coordinator.client.push_button.assert_not_awaited()
+
+
+def _coordinator() -> tuple[NanoKVMDataUpdateCoordinator, MagicMock]:
+    """Create a coordinator with mocked Home Assistant dependencies."""
+    hass = MagicMock()
+    entry = MagicMock(spec=ConfigEntry)
+    coordinator = NanoKVMDataUpdateCoordinator(
+        hass,
+        entry,
+        client=MagicMock(),
+        username="admin",
+        password="password",
+        device_info=SimpleNamespace(device_key="test-device", application="1.0.0"),
+    )
+    return coordinator, entry
+
+
+def test_coordinator_registers_config_entry_with_base_class() -> None:
+    """The base coordinator must own config-entry unload registration."""
+    coordinator, entry = _coordinator()
+
+    assert coordinator.config_entry is entry
+    entry.async_on_unload.assert_called_once_with(coordinator.async_shutdown)
+
+
+def test_coordinator_shutdown_stops_base_and_owned_resources() -> None:
+    """Shutdown must stop refreshes, cancel background work, and disconnect SSH."""
+
+    async def run_shutdown() -> None:
+        coordinator, _ = _coordinator()
+        app_version_task = asyncio.create_task(asyncio.Event().wait())
+        collector = SimpleNamespace(disconnect=AsyncMock())
+        coordinator._app_version_fetch_task = app_version_task
+        coordinator.ssh_metrics_collector = collector
+
+        await coordinator.async_shutdown()
+
+        assert coordinator._shutdown_requested is True
+        assert app_version_task.cancelled()
+        assert coordinator._app_version_fetch_task is None
+        collector.disconnect.assert_awaited_once_with()
+        assert coordinator.ssh_metrics_collector is None
+
+    asyncio.run(run_shutdown())
+
+
+def test_integration_unload_leaves_coordinator_shutdown_to_config_entry() -> None:
+    """Integration unload must not invoke the registered coordinator callback twice."""
+
+    async def run_unload() -> None:
+        hass = MagicMock()
+        hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+        entry = MagicMock(spec=ConfigEntry)
+        entry.entry_id = "test-entry"
+        coordinator = SimpleNamespace(async_shutdown=AsyncMock())
+        hass.data = {DOMAIN: {entry.entry_id: coordinator}}
+        hass.services.has_service.return_value = False
+
+        assert await async_unload_entry(hass, entry) is True
+
+        coordinator.async_shutdown.assert_not_awaited()
+        assert DOMAIN not in hass.data
+
+    asyncio.run(run_unload())


### PR DESCRIPTION
## Summary

- Refresh the NanoKVM power state before sending a power-button command.
- Avoid pressing the momentary power button when the host is already in the requested state.
- Register the config entry with `DataUpdateCoordinator`.
- Let Home Assistant manage coordinator shutdown during config-entry unload.
- Call the base coordinator shutdown implementation before cleaning up integration-owned resources.
- Add regression tests for power-state handling and coordinator lifecycle behavior.

## Root cause

The power switch uses the same momentary power-button action for both `turn_on` and `turn_off`. Repeated or stale commands could therefore press the button even when the host was already in the requested state.

The coordinator also managed part of its lifecycle manually instead of registering the config entry with Home Assistant's base coordinator. This could bypass base cleanup behavior or cause shutdown to run twice during unload.
