### PR TITLE
fix: serialize shared NanoKVM client access

### DIFF
--- a/custom_components/nanokvm/button.py
+++ b/custom_components/nanokvm/button.py
@@ -135,6 +135,6 @@ class NanoKVMButton(NanoKVMEntity, ButtonEntity):
         """Press the button."""
         if self.entity_description.press_fn is None:
             raise RuntimeError(f"Missing press handler for button: {self.entity_description.key}")
-        async with self.coordinator.client:
+        async with self.coordinator.async_client():
             await self.entity_description.press_fn(self.coordinator)
         await self.coordinator.async_request_refresh()

--- a/custom_components/nanokvm/coordinator.py
+++ b/custom_components/nanokvm/coordinator.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
 import contextlib
 import datetime
 import logging
@@ -135,6 +136,7 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
         self.watchdog_enabled = None
         self._app_version_last_fetched: datetime.datetime | None = None
         self._app_version_fetch_task: asyncio.Task[None] | None = None
+        self._client_lock = asyncio.Lock()
 
         super().__init__(
             hass,
@@ -143,6 +145,13 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
             name=DOMAIN,
             update_interval=datetime.timedelta(seconds=DEFAULT_SCAN_INTERVAL),
         )
+
+    @contextlib.asynccontextmanager
+    async def async_client(self) -> AsyncIterator[NanoKVMClient]:
+        """Yield the shared API client to one caller at a time."""
+        async with self._client_lock:
+            async with self.client as client:
+                yield client
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from NanoKVM."""
@@ -224,20 +233,29 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_fetch_with_client(self) -> dict[str, Any]:
         """Fetch data using the current client instance."""
-        async with self.client, asyncio.timeout(_UPDATE_TIMEOUT_SECONDS):
-            if not self.client.token:
-                await self.client.authenticate(self.username, self.password)
+        async with self.async_client() as client:
+            async with asyncio.timeout(_UPDATE_TIMEOUT_SECONDS):
+                if not client.token:
+                    await client.authenticate(self.username, self.password)
 
-            await self._async_fetch_core_data()
-            self._async_maybe_create_network_entities()
-            await self._async_fetch_storage_data()
-            self._async_maybe_create_media_entities()
-            await self._async_refresh_ssh_data()
-            self._async_schedule_app_version_refresh()
-            return self._build_update_data()
+                await self._async_fetch_core_data()
+                self._async_maybe_create_network_entities()
+                await self._async_fetch_storage_data()
+                self._async_maybe_create_media_entities()
+
+        await self._async_refresh_ssh_data()
+        self._async_schedule_app_version_refresh()
+        return self._build_update_data()
 
     async def _async_reauthenticate_client(self, original_error: Exception) -> None:
         """Reauthenticate and replace the client when token/auth fails."""
+        async with self._client_lock:
+            await self._async_reauthenticate_client_locked(original_error)
+
+    async def _async_reauthenticate_client_locked(
+        self, original_error: Exception
+    ) -> None:
+        """Reauthenticate and replace the client while access is serialized."""
         options = api_connection_options(
             self.config_entry.data[CONF_HOST],
             self.config_entry.data.get(CONF_SSL_FINGERPRINT),
@@ -297,6 +315,11 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_failover_client(self, original_error: Exception) -> bool:
         """Switch to an alternate API transport after a connection failure."""
+        async with self._client_lock:
+            return await self._async_failover_client_locked(original_error)
+
+    async def _async_failover_client_locked(self, original_error: Exception) -> bool:
+        """Switch transports while access to the shared client is serialized."""
         options = api_connection_options(
             self.config_entry.data[CONF_HOST],
             self.config_entry.data.get(CONF_SSL_FINGERPRINT),

--- a/custom_components/nanokvm/number.py
+++ b/custom_components/nanokvm/number.py
@@ -249,7 +249,7 @@ class NanoKVMNumber(NanoKVMEntity, NumberEntity):
             )
 
         try:
-            async with self.coordinator.client:
+            async with self.coordinator.async_client():
                 await self.entity_description.set_value_fn(self.coordinator, value)
         except ValueError as err:
             raise HomeAssistantError(str(err)) from err

--- a/custom_components/nanokvm/select.py
+++ b/custom_components/nanokvm/select.py
@@ -342,6 +342,6 @@ class NanoKVMSelect(NanoKVMEntity, SelectEntity):
         """Change the selected option."""
         if self.entity_description.select_option_fn is None:
             raise RuntimeError(f"Missing select handler for select: {self.entity_description.key}")
-        async with self.coordinator.client:
+        async with self.coordinator.async_client():
             await self.entity_description.select_option_fn(self.coordinator, option)
         await self.coordinator.async_request_refresh()

--- a/custom_components/nanokvm/services.py
+++ b/custom_components/nanokvm/services.py
@@ -192,11 +192,10 @@ def async_register_services(hass: HomeAssistant) -> None:
     ) -> None:
         """Execute a service on the targeted NanoKVM device."""
         coordinator = _resolve_target_coordinator(call)
-        client = coordinator.client
         host = coordinator.config_entry.data.get(CONF_HOST, "<unknown>")
 
         try:
-            async with client:
+            async with coordinator.async_client() as client:
                 await handler(coordinator, client, host)
         except HomeAssistantError:
             raise
@@ -217,11 +216,10 @@ def async_register_services(hass: HomeAssistant) -> None:
     ) -> ServiceResponse:
         """Execute a response-returning service on the targeted NanoKVM device."""
         coordinator = _resolve_target_coordinator(call)
-        client = coordinator.client
         host = coordinator.config_entry.data.get(CONF_HOST, "<unknown>")
 
         try:
-            async with client:
+            async with coordinator.async_client() as client:
                 return _model_to_response(await handler(coordinator, client, host))
         except HomeAssistantError:
             raise

--- a/custom_components/nanokvm/switch.py
+++ b/custom_components/nanokvm/switch.py
@@ -397,7 +397,7 @@ class NanoKVMSwitch(NanoKVMEntity, SwitchEntity):
         """Turn on the switch."""
         if self.entity_description.turn_on_fn is None:
             raise RuntimeError(f"Missing turn_on handler for switch: {self.entity_description.key}")
-        async with self.coordinator.client:
+        async with self.coordinator.async_client():
             await self.entity_description.turn_on_fn(self.coordinator)
         await self.coordinator.async_request_refresh()
 
@@ -405,7 +405,7 @@ class NanoKVMSwitch(NanoKVMEntity, SwitchEntity):
         """Turn off the switch."""
         if self.entity_description.turn_off_fn is None:
             raise RuntimeError(f"Missing turn_off handler for switch: {self.entity_description.key}")
-        async with self.coordinator.client:
+        async with self.coordinator.async_client():
             await self.entity_description.turn_off_fn(self.coordinator)
         await self.coordinator.async_request_refresh()
 
@@ -427,7 +427,7 @@ class NanoKVMPowerSwitch(NanoKVMSwitch):
             raise RuntimeError(f"Missing turn_on handler for switch: {self.entity_description.key}")
         if await self._async_current_power_state() is True:
             return
-        async with self.coordinator.client:
+        async with self.coordinator.async_client():
             await self.entity_description.turn_on_fn(self.coordinator)
         await asyncio.sleep(1)
         await self.coordinator.async_request_refresh()
@@ -439,7 +439,7 @@ class NanoKVMPowerSwitch(NanoKVMSwitch):
             raise RuntimeError(f"Missing turn_off handler for switch: {self.entity_description.key}")
         if await self._async_current_power_state() is False:
             return
-        async with self.coordinator.client:
+        async with self.coordinator.async_client():
             await self.entity_description.turn_off_fn(self.coordinator)
 
         SHUTDOWN_TIMEOUT = 300
@@ -472,8 +472,8 @@ class NanoKVMVirtualDeviceSwitch(NanoKVMSwitch):
         if self.is_on == enabled:
             return
 
-        async with self.coordinator.client:
-            await self.coordinator.client.update_virtual_device(virtual_device)
+        async with self.coordinator.async_client() as client:
+            await client.update_virtual_device(virtual_device)
         await self.coordinator.async_request_refresh()
 
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/custom_components/nanokvm/update.py
+++ b/custom_components/nanokvm/update.py
@@ -136,8 +136,8 @@ class NanoKVMUpdate(NanoKVMEntity, UpdateEntity):
         del version, backup, kwargs
         should_refresh = True
         try:
-            async with self.coordinator.client:
-                await self.coordinator.client.update_application()
+            async with self.coordinator.async_client() as client:
+                await client.update_application()
         except aiohttp.ServerDisconnectedError:
             should_refresh = False
             _LOGGER.debug(

--- a/tests/test_client_access.py
+++ b/tests/test_client_access.py
@@ -1,0 +1,181 @@
+"""Regression tests for serialized coordinator client access."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST
+from pytest import MonkeyPatch
+from yarl import URL
+
+import custom_components.nanokvm.coordinator as coordinator_module
+from custom_components.nanokvm.coordinator import NanoKVMDataUpdateCoordinator
+
+
+class TrackingClient:
+    """Async context manager that records overlapping entries."""
+
+    def __init__(self, url: str = "http://nanokvm.local/api/") -> None:
+        self.active_entries = 0
+        self.maximum_active_entries = 0
+        self.token = "authenticated"
+        self.url = URL(url)
+
+    async def __aenter__(self) -> TrackingClient:
+        """Record an active client user."""
+        self.active_entries += 1
+        self.maximum_active_entries = max(
+            self.maximum_active_entries, self.active_entries
+        )
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        """Record a completed client user."""
+        self.active_entries -= 1
+
+
+class DirectEntryForbiddenClient(TrackingClient):
+    """Client that fails when code bypasses the coordinator access boundary."""
+
+    token = "authenticated"
+
+    async def __aenter__(self) -> DirectEntryForbiddenClient:
+        """Reject direct context entry."""
+        raise AssertionError("shared client was entered directly")
+
+
+def _coordinator(client: TrackingClient) -> NanoKVMDataUpdateCoordinator:
+    """Create a coordinator backed by the tracking client."""
+    entry = MagicMock(spec=ConfigEntry)
+    entry.data = {CONF_HOST: "http://nanokvm.local"}
+    return NanoKVMDataUpdateCoordinator(
+        MagicMock(),
+        entry,
+        client=client,
+        username="admin",
+        password="password",
+        device_info=SimpleNamespace(device_key="test-device", application="1.0.0"),
+    )
+
+
+def test_coordinator_serializes_shared_client_users() -> None:
+    """A second client user must wait until the first user exits."""
+
+    async def run_test() -> None:
+        client = TrackingClient()
+        coordinator = _coordinator(client)
+        async_client = coordinator.async_client
+        first_entered = asyncio.Event()
+        release_first = asyncio.Event()
+        second_entered = asyncio.Event()
+
+        async def first_user() -> None:
+            async with async_client():
+                first_entered.set()
+                await release_first.wait()
+
+        async def second_user() -> None:
+            async with async_client():
+                second_entered.set()
+
+        first_task = asyncio.create_task(first_user())
+        await first_entered.wait()
+        second_task = asyncio.create_task(second_user())
+        await asyncio.sleep(0)
+
+        assert not second_entered.is_set()
+        release_first.set()
+        await asyncio.gather(first_task, second_task)
+        assert second_entered.is_set()
+        assert client.maximum_active_entries == 1
+
+    asyncio.run(run_test())
+
+
+def test_cancelled_client_user_releases_serialized_access() -> None:
+    """Cancellation must release the client context and coordinator lock."""
+
+    async def run_test() -> None:
+        client = TrackingClient()
+        coordinator = _coordinator(client)
+        entered = asyncio.Event()
+
+        async def cancelled_user() -> None:
+            async with coordinator.async_client():
+                entered.set()
+                await asyncio.Event().wait()
+
+        task = asyncio.create_task(cancelled_user())
+        await entered.wait()
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        assert client.active_entries == 0
+        async with asyncio.timeout(1), coordinator.async_client():
+            pass
+
+    asyncio.run(run_test())
+
+
+def test_coordinator_poll_uses_serialized_client_access() -> None:
+    """Coordinator polling must enter the client through its access boundary."""
+
+    async def run_test() -> None:
+        client = DirectEntryForbiddenClient()
+        coordinator = _coordinator(client)
+
+        @contextlib.asynccontextmanager
+        async def serialized_client():
+            yield client
+
+        coordinator.async_client = MagicMock(side_effect=serialized_client)
+        coordinator._async_fetch_core_data = AsyncMock()
+        coordinator._async_fetch_storage_data = AsyncMock()
+        coordinator._async_refresh_ssh_data = AsyncMock()
+        coordinator._async_maybe_create_network_entities = MagicMock()
+        coordinator._async_maybe_create_media_entities = MagicMock()
+        coordinator._async_schedule_app_version_refresh = MagicMock()
+        coordinator._build_update_data = MagicMock(return_value={"ready": True})
+
+        assert await coordinator._async_fetch_with_client() == {"ready": True}
+        coordinator.async_client.assert_called_once_with()
+
+    asyncio.run(run_test())
+
+
+def test_client_replacement_waits_for_active_user(monkeypatch: MonkeyPatch) -> None:
+    """Reauthentication must not replace a client that is still in use."""
+
+    async def run_test() -> None:
+        replacement_started = asyncio.Event()
+
+        class ReplacementClient(TrackingClient):
+            """Candidate client used by the reauthentication path."""
+
+            def __init__(self, url: str, **_: object) -> None:
+                super().__init__(url)
+
+            async def authenticate(self, _username: str, _password: str) -> None:
+                replacement_started.set()
+
+        monkeypatch.setattr(coordinator_module, "NanoKVMClient", ReplacementClient)
+        current_client = TrackingClient()
+        coordinator = _coordinator(current_client)
+
+        async with coordinator.async_client():
+            replacement_task = asyncio.create_task(
+                coordinator._async_reauthenticate_client(RuntimeError("reauthenticate"))
+            )
+            await asyncio.sleep(0)
+            assert not replacement_started.is_set()
+
+        await replacement_task
+        assert replacement_started.is_set()
+        assert coordinator.client is not current_client
+
+    asyncio.run(run_test())

--- a/tests/test_power_and_lifecycle.py
+++ b/tests/test_power_and_lifecycle.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.config_entries import ConfigEntry
+from nanokvm.models import GpioType
+from pytest import MonkeyPatch
 
 from custom_components.nanokvm import async_unload_entry
 from custom_components.nanokvm.const import DOMAIN
@@ -16,6 +19,7 @@ from custom_components.nanokvm.switch import (
     NanoKVMPowerSwitch,
     NanoKVMSwitchEntityDescription,
 )
+import custom_components.nanokvm.switch as switch_module
 
 
 class FakeClient:
@@ -26,9 +30,8 @@ class FakeClient:
         self.push_button = AsyncMock()
 
     async def __aenter__(self) -> FakeClient:
-        """Enter the fake client context."""
-        self.enter_count += 1
-        return self
+        """Reject entity code that enters the shared client directly."""
+        raise AssertionError("power switch bypassed coordinator client access")
 
     async def __aexit__(self, *_: object) -> None:
         """Exit the fake client context."""
@@ -41,9 +44,17 @@ def _power_description() -> NanoKVMSwitchEntityDescription:
 
 def _power_switch(power_state: bool) -> tuple[NanoKVMPowerSwitch, SimpleNamespace]:
     """Create a power switch backed by a minimal coordinator."""
+    client = FakeClient()
+
+    @contextlib.asynccontextmanager
+    async def async_client():
+        client.enter_count += 1
+        yield client
+
     coordinator = SimpleNamespace(
+        async_client=MagicMock(side_effect=async_client),
         async_request_refresh=AsyncMock(),
-        client=FakeClient(),
+        client=client,
         device_info=SimpleNamespace(device_key="test-device"),
         gpio_info=SimpleNamespace(pwr=power_state),
     )
@@ -70,6 +81,22 @@ def test_power_turn_off_is_noop_when_already_off() -> None:
     coordinator.async_request_refresh.assert_awaited_once_with()
     assert coordinator.client.enter_count == 0
     coordinator.client.push_button.assert_not_awaited()
+
+
+def test_power_turn_on_uses_coordinator_client_access(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A power action must use serialized coordinator client access."""
+    switch, coordinator = _power_switch(False)
+    sleep = AsyncMock()
+    monkeypatch.setattr(switch_module.asyncio, "sleep", sleep)
+
+    asyncio.run(switch.async_turn_on())
+
+    coordinator.async_client.assert_called_once_with()
+    coordinator.client.push_button.assert_awaited_once_with(GpioType.POWER, 200)
+    assert coordinator.client.enter_count == 1
+    sleep.assert_awaited_once_with(1)
 
 
 def _coordinator() -> tuple[NanoKVMDataUpdateCoordinator, MagicMock]:


### PR DESCRIPTION
## Summary

- add coordinator-owned serialized access to the shared NanoKVM API client
- protect reauthentication, transport failover, and client replacement with the same lock
- route polling, services, and actionable entities through the coordinator access boundary
- keep dedicated camera and WebRTC client lifecycles unchanged
- add regression coverage for concurrent access, cancellation, replacement, polling, and power actions

## Problem

Coordinator polling, services, and entity actions could enter the same NanoKVMClient concurrently. Because the client closes its internally owned HTTP session whenever a context exits, one operation could invalidate the session while another operation was still using it.

## Impact

Shared API operations now wait for the active client user to finish, preventing intermittent closed-session and assertion failures. Client recovery and replacement are serialized with normal API calls, while SSH and dedicated media work remain independent.