### PR TITLE
fix: improve coordinator connection reliability

### DIFF
--- a/custom_components/nanokvm/__init__.py
+++ b/custom_components/nanokvm/__init__.py
@@ -76,7 +76,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             raise ConfigEntryAuthFailed(
                 f"SSL certificate changed for NanoKVM at {host}"
             ) from err
-        except aiohttp.ClientConnectorError as err:
+        except aiohttp.ClientConnectionError as err:
             last_error = err
             if index < len(options) - 1:
                 continue

--- a/custom_components/nanokvm/config_flow.py
+++ b/custom_components/nanokvm/config_flow.py
@@ -55,7 +55,7 @@ async def validate_input(data: dict[str, Any]) -> str:
                     last_error = err
                     continue
                 raise SSLCertificateChanged from err
-            except aiohttp.ClientConnectorError as err:
+            except aiohttp.ClientConnectionError as err:
                 last_error = err
                 if index < len(options) - 1:
                     continue

--- a/custom_components/nanokvm/coordinator.py
+++ b/custom_components/nanokvm/coordinator.py
@@ -203,7 +203,7 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
             raise ConfigEntryAuthFailed(
                 "SSL certificate changed for NanoKVM"
             ) from err
-        except aiohttp.ClientConnectorError as err:
+        except aiohttp.ClientConnectionError as err:
             if await self._async_failover_client(err):
                 return await self._async_fetch_with_client()
             raise UpdateFailed(f"Error communicating with NanoKVM: {err}") from err
@@ -296,7 +296,7 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
                 raise ConfigEntryAuthFailed(
                     "SSL certificate changed for NanoKVM"
                 ) from auth_err
-            except aiohttp.ClientConnectorError as auth_err:
+            except aiohttp.ClientConnectionError as auth_err:
                 last_error = auth_err
                 continue
             except asyncio.TimeoutError:

--- a/custom_components/nanokvm/coordinator.py
+++ b/custom_components/nanokvm/coordinator.py
@@ -52,6 +52,7 @@ _LOGGER = logging.getLogger(__name__)
 _UPDATE_MAX_ATTEMPTS = 3
 _UPDATE_RETRY_DELAY_SECONDS = 1
 _UPDATE_TIMEOUT_SECONDS = 10
+_SSH_METRICS_TIMEOUT_SECONDS = 15
 _APP_VERSION_REQUEST_TIMEOUT_SECONDS = 45
 _APP_VERSION_CACHE_SECONDS = 300
 _APP_VERSION_FAILURE_CACHE_SECONDS = 60
@@ -569,7 +570,18 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_refresh_ssh_data(self) -> None:
         """Fetch or clear SSH metrics depending on SSH state."""
         if self.ssh_state and self.ssh_state.enabled:
-            await self._async_update_ssh_data()
+            try:
+                async with asyncio.timeout(_SSH_METRICS_TIMEOUT_SECONDS):
+                    await self._async_update_ssh_data()
+            except TimeoutError:
+                _LOGGER.debug(
+                    "Timed out fetching optional SSH metrics after %s seconds",
+                    _SSH_METRICS_TIMEOUT_SECONDS,
+                )
+                await self._async_clear_ssh_data()
+            except asyncio.CancelledError:
+                await self._async_clear_ssh_data()
+                raise
         else:
             await self._async_clear_ssh_data()
 

--- a/custom_components/nanokvm/coordinator.py
+++ b/custom_components/nanokvm/coordinator.py
@@ -212,6 +212,10 @@ class NanoKVMDataUpdateCoordinator(DataUpdateCoordinator):
                 await self._async_reauthenticate_client(err)
                 try:
                     return await self._async_fetch_with_client()
+                except asyncio.TimeoutError:
+                    raise UpdateFailed(
+                        _format_timeout_error("communicating with NanoKVM")
+                    ) from None
                 except (aiohttp.ClientResponseError, NanoKVMAuthenticationFailure) as reauth_err:
                     if _is_auth_failure(reauth_err):
                         raise ConfigEntryAuthFailed(

--- a/custom_components/nanokvm/utils.py
+++ b/custom_components/nanokvm/utils.py
@@ -75,7 +75,11 @@ class NanoKVMConnectionTarget:
     @property
     def match_key(self) -> tuple[str, int | None, str]:
         """Return a normalized key for matching configured devices."""
-        return self.ssh_host, self.origin.port, _normalize_api_path(self.origin.path)
+        return (
+            self.ssh_host,
+            self.origin.explicit_port,
+            _normalize_api_path(self.origin.path),
+        )
 
     def api_connection_options(
         self,

--- a/tests/test_connection_failover.py
+++ b/tests/test_connection_failover.py
@@ -1,0 +1,192 @@
+"""Regression tests for NanoKVM transport failover."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from pytest import MonkeyPatch
+from yarl import URL
+
+import custom_components.nanokvm as nanokvm_module
+import custom_components.nanokvm.config_flow as config_flow_module
+import custom_components.nanokvm.coordinator as coordinator_module
+from custom_components.nanokvm.coordinator import NanoKVMDataUpdateCoordinator
+
+
+def _coordinator() -> NanoKVMDataUpdateCoordinator:
+    """Create a coordinator with mocked Home Assistant dependencies."""
+    entry = MagicMock(spec=ConfigEntry)
+    entry.data = {CONF_HOST: "nanokvm.local"}
+    client = MagicMock()
+    client.url = URL("http://nanokvm.local/api/")
+    return NanoKVMDataUpdateCoordinator(
+        MagicMock(),
+        entry,
+        client=client,
+        username="admin",
+        password="password",
+        device_info=SimpleNamespace(device_key="test-device", application="1.0.0"),
+    )
+
+
+def test_runtime_disconnect_tries_alternate_transport() -> None:
+    """A server disconnect must trigger the configured transport fallback."""
+
+    async def run_test() -> None:
+        coordinator = _coordinator()
+        disconnect = aiohttp.ServerDisconnectedError("HTTP probe disconnected")
+        coordinator._async_fetch_with_client = AsyncMock(
+            side_effect=[disconnect, {"transport": "https"}]
+        )
+        coordinator._async_failover_client = AsyncMock(return_value=True)
+
+        assert await coordinator._async_fetch_once() == {"transport": "https"}
+        coordinator._async_failover_client.assert_awaited_once_with(disconnect)
+        assert coordinator._async_fetch_with_client.await_count == 2
+
+    asyncio.run(run_test())
+
+
+def test_config_validation_disconnect_tries_https(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Config validation must try HTTPS when the HTTP probe disconnects."""
+
+    async def run_test() -> None:
+        attempted_urls: list[str] = []
+
+        class FakeClient:
+            """Client that disconnects on HTTP and succeeds on HTTPS."""
+
+            def __init__(self, url: str, **_: object) -> None:
+                self.url = URL(url)
+                attempted_urls.append(url)
+
+            async def __aenter__(self) -> FakeClient:
+                return self
+
+            async def __aexit__(self, *_: object) -> None:
+                return None
+
+            async def authenticate(self, _username: str, _password: str) -> None:
+                if self.url.scheme == "http":
+                    raise aiohttp.ServerDisconnectedError("HTTP probe disconnected")
+
+            async def get_info(self) -> SimpleNamespace:
+                return SimpleNamespace(device_key="https-device")
+
+        monkeypatch.setattr(config_flow_module, "NanoKVMClient", FakeClient)
+
+        assert await config_flow_module.validate_input(
+            {
+                CONF_HOST: "nanokvm.local",
+                CONF_USERNAME: "admin",
+                CONF_PASSWORD: "password",
+            }
+        ) == "https-device"
+        assert [URL(url).scheme for url in attempted_urls] == ["http", "https"]
+
+    asyncio.run(run_test())
+
+
+def test_entry_setup_disconnect_tries_https(monkeypatch: MonkeyPatch) -> None:
+    """Config-entry setup must try HTTPS when the HTTP probe disconnects."""
+
+    async def run_test() -> None:
+        attempted_urls: list[str] = []
+
+        class FakeClient:
+            """Client that disconnects on HTTP and succeeds on HTTPS."""
+
+            def __init__(self, url: str, **_: object) -> None:
+                self.url = URL(url)
+                attempted_urls.append(url)
+
+            async def __aenter__(self) -> FakeClient:
+                return self
+
+            async def __aexit__(self, *_: object) -> None:
+                return None
+
+            async def authenticate(self, _username: str, _password: str) -> None:
+                if self.url.scheme == "http":
+                    raise aiohttp.ServerDisconnectedError("HTTP probe disconnected")
+
+            async def get_info(self) -> SimpleNamespace:
+                return SimpleNamespace(
+                    device_key="https-device",
+                    application="1.0.0",
+                )
+
+        coordinator = SimpleNamespace(async_config_entry_first_refresh=AsyncMock())
+        coordinator_factory = MagicMock(return_value=coordinator)
+        monkeypatch.setattr(nanokvm_module, "NanoKVMClient", FakeClient)
+        monkeypatch.setattr(
+            nanokvm_module,
+            "NanoKVMDataUpdateCoordinator",
+            coordinator_factory,
+        )
+        register_services = MagicMock()
+        monkeypatch.setattr(
+            nanokvm_module,
+            "async_register_services",
+            register_services,
+        )
+        hass = MagicMock()
+        hass.data = {}
+        hass.config_entries.async_forward_entry_setups = AsyncMock()
+        entry = MagicMock(spec=ConfigEntry)
+        entry.entry_id = "test-entry"
+        entry.data = {
+            CONF_HOST: "nanokvm.local",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "password",
+        }
+
+        assert await nanokvm_module.async_setup_entry(hass, entry) is True
+        assert [URL(url).scheme for url in attempted_urls] == ["http", "https"]
+        assert coordinator_factory.call_args.kwargs["client"].url.scheme == "https"
+        coordinator.async_config_entry_first_refresh.assert_awaited_once_with()
+        hass.config_entries.async_forward_entry_setups.assert_awaited_once()
+        register_services.assert_called_once_with(hass)
+
+    asyncio.run(run_test())
+
+
+def test_reauthentication_disconnect_tries_https(monkeypatch: MonkeyPatch) -> None:
+    """Reauthentication must try HTTPS when the HTTP candidate disconnects."""
+
+    async def run_test() -> None:
+        attempted_urls: list[str] = []
+
+        class FakeClient:
+            """Client that disconnects on HTTP and authenticates on HTTPS."""
+
+            def __init__(self, url: str, **_: object) -> None:
+                self.url = URL(url)
+                attempted_urls.append(url)
+
+            async def __aenter__(self) -> FakeClient:
+                return self
+
+            async def __aexit__(self, *_: object) -> None:
+                return None
+
+            async def authenticate(self, _username: str, _password: str) -> None:
+                if self.url.scheme == "http":
+                    raise aiohttp.ServerDisconnectedError("HTTP probe disconnected")
+
+        monkeypatch.setattr(coordinator_module, "NanoKVMClient", FakeClient)
+        coordinator = _coordinator()
+
+        await coordinator._async_reauthenticate_client(RuntimeError("expired token"))
+
+        assert [URL(url).scheme for url in attempted_urls] == ["http", "https"]
+        assert coordinator.client.url.scheme == "https"
+
+    asyncio.run(run_test())

--- a/tests/test_coordinator_reauthentication.py
+++ b/tests/test_coordinator_reauthentication.py
@@ -1,0 +1,53 @@
+"""Regression tests for coordinator reauthentication error handling."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.config_entries import ConfigEntry
+from nanokvm.client import NanoKVMAuthenticationFailure
+from pytest import raises
+
+from custom_components.nanokvm.coordinator import (
+    NanoKVMDataUpdateCoordinator,
+    UpdateFailed,
+)
+
+
+def _coordinator() -> NanoKVMDataUpdateCoordinator:
+    """Create a coordinator with mocked Home Assistant dependencies."""
+    return NanoKVMDataUpdateCoordinator(
+        MagicMock(),
+        MagicMock(spec=ConfigEntry),
+        client=MagicMock(),
+        username="admin",
+        password="password",
+        device_info=SimpleNamespace(device_key="test-device", application="1.0.0"),
+    )
+
+
+def test_post_reauthentication_timeout_uses_update_failed_contract() -> None:
+    """A timed-out fetch after reauthentication must remain retryable."""
+
+    async def run_test() -> None:
+        coordinator = _coordinator()
+        coordinator._async_fetch_with_client = AsyncMock(
+            side_effect=[
+                NanoKVMAuthenticationFailure("expired token"),
+                asyncio.TimeoutError(),
+            ]
+        )
+        coordinator._async_reauthenticate_client = AsyncMock()
+
+        with raises(
+            UpdateFailed,
+            match="Timed out communicating with NanoKVM after 10 seconds",
+        ):
+            await coordinator._async_fetch_once()
+
+        coordinator._async_reauthenticate_client.assert_awaited_once()
+        assert coordinator._async_fetch_with_client.await_count == 2
+
+    asyncio.run(run_test())

--- a/tests/test_ssh_metrics_lifecycle.py
+++ b/tests/test_ssh_metrics_lifecycle.py
@@ -1,0 +1,96 @@
+"""Regression tests for optional SSH metrics lifecycle handling."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST
+from pytest import MonkeyPatch, raises
+
+import custom_components.nanokvm.coordinator as coordinator_module
+from custom_components.nanokvm.coordinator import NanoKVMDataUpdateCoordinator
+
+
+def _coordinator() -> NanoKVMDataUpdateCoordinator:
+    """Create a coordinator configured with SSH enabled."""
+    entry = MagicMock(spec=ConfigEntry)
+    entry.data = {CONF_HOST: "http://nanokvm.local"}
+    coordinator = NanoKVMDataUpdateCoordinator(
+        MagicMock(),
+        entry,
+        client=MagicMock(),
+        username="admin",
+        password="password",
+        device_info=SimpleNamespace(device_key="test-device", application="1.0.0"),
+    )
+    coordinator.ssh_state = SimpleNamespace(enabled=True)
+    return coordinator
+
+
+def test_stalled_ssh_metrics_do_not_block_coordinator_refresh(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A stalled optional SSH collector must time out without failing the poll."""
+
+    async def run_test() -> None:
+        coordinator = _coordinator()
+        stalled = asyncio.Event()
+
+        async def collect(*, include_watchdog: bool) -> None:
+            del include_watchdog
+            await stalled.wait()
+
+        collector = SimpleNamespace(
+            collect=collect,
+            disconnect=AsyncMock(),
+        )
+        coordinator.ssh_metrics_collector = collector
+        coordinator.uptime = "previous uptime"
+        coordinator.cpu_temperature = 55.0
+        monkeypatch.setattr(
+            coordinator_module,
+            "_SSH_METRICS_TIMEOUT_SECONDS",
+            0.01,
+        )
+
+        await asyncio.wait_for(coordinator._async_refresh_ssh_data(), timeout=0.2)
+
+        assert coordinator.uptime is None
+        assert coordinator.cpu_temperature is None
+        collector.disconnect.assert_awaited_once_with()
+
+    asyncio.run(run_test())
+
+
+def test_cancelled_ssh_metrics_disconnect_before_propagating() -> None:
+    """Coordinator cancellation must disconnect an in-flight SSH collector."""
+
+    async def run_test() -> None:
+        coordinator = _coordinator()
+        collect_started = asyncio.Event()
+
+        async def collect(*, include_watchdog: bool) -> None:
+            del include_watchdog
+            collect_started.set()
+            await asyncio.Event().wait()
+
+        collector = SimpleNamespace(
+            collect=collect,
+            disconnect=AsyncMock(),
+        )
+        coordinator.ssh_metrics_collector = collector
+        coordinator.uptime = "previous uptime"
+        task = asyncio.create_task(coordinator._async_refresh_ssh_data())
+        await collect_started.wait()
+
+        task.cancel()
+        with raises(asyncio.CancelledError):
+            await task
+
+        assert coordinator.uptime is None
+        collector.disconnect.assert_awaited_once_with()
+
+    asyncio.run(run_test())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,18 @@
+"""Regression tests for NanoKVM host normalization helpers."""
+
+from custom_components.nanokvm.utils import host_match_key
+
+
+def test_host_match_key_ignores_default_transport_scheme() -> None:
+    """Bare, HTTP, and HTTPS default URLs must identify the same device."""
+    bare_key = host_match_key("nanokvm.local")
+
+    assert host_match_key("http://nanokvm.local") == bare_key
+    assert host_match_key("https://nanokvm.local") == bare_key
+
+
+def test_host_match_key_preserves_explicit_custom_ports() -> None:
+    """Explicit custom ports must continue to identify distinct targets."""
+    assert host_match_key("https://nanokvm.local:8443") != host_match_key(
+        "https://nanokvm.local:9443"
+    )


### PR DESCRIPTION
## Summary

- bound optional SSH metric collection with cancellation-safe cleanup
- preserve Home Assistant's retry contract when a fetch times out after reauthentication
- broaden HTTP-to-HTTPS fallback to cover general aiohttp connection failures
- normalize default service-target ports across bare, HTTP, and HTTPS hosts
- add regression coverage for SSH lifecycle, reauthentication, connection failover, and host matching

## Problem

Several coordinator recovery paths could either block updates or bypass intended fallback/retry behavior. Optional SSH collection could stall an entire refresh, a post-reauthentication timeout escaped as a raw TimeoutError, and common disconnect errors skipped HTTPS fallback. Service targeting also treated default HTTP and HTTPS ports as different devices.

## Impact

Coordinator updates remain available when optional SSH work stalls, recovery failures follow Home Assistant's retry contract, and transport fallback handles common connection failures consistently. Service calls can target the same device regardless of whether its default transport is written as a bare, HTTP, or HTTPS URL.