### PR TITLE
test: expand core integration coverage

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 addopts = --strict-config --strict-markers
+asyncio_mode = auto
 testpaths = tests

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,4 +2,5 @@ coverage>=7.10.6,<8.0
 homeassistant==2026.5.1
 nanokvm==1.2.0
 pytest>=9.0,<10.0
+pytest-asyncio>=1.4,<2.0
 ruff>=0.15,<1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+"""Shared pytest fixtures for Home Assistant integration-boundary tests."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+import pytest
+
+
+@pytest.fixture
+def hass_mock() -> MagicMock:
+    """Return a Home Assistant mock with integration storage initialized."""
+    hass = MagicMock(spec=HomeAssistant)
+    hass.data = {}
+    return hass
+
+
+@pytest.fixture
+def config_entry_mock() -> MagicMock:
+    """Return a complete NanoKVM config-entry mock."""
+    entry = MagicMock(spec=ConfigEntry)
+    entry.entry_id = "test-entry"
+    entry.unique_id = "test-device"
+    entry.data = {
+        CONF_HOST: "nanokvm.local",
+        CONF_USERNAME: "admin",
+        CONF_PASSWORD: "password",
+    }
+    return entry

--- a/tests/core/test_config_flow.py
+++ b/tests/core/test_config_flow.py
@@ -1,0 +1,1073 @@
+"""Tests for NanoKVM config-flow behavior and transport validation."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.data_entry_flow import AbortFlow, FlowResultType
+from nanokvm.client import (
+    NanoKVMAuthenticationFailure,
+    NanoKVMError,
+)
+import pytest
+from yarl import URL
+
+import custom_components.nanokvm.config_flow as config_flow_module
+from custom_components.nanokvm.config_flow import (
+    CannotConnect,
+    InvalidAuth,
+    NanoKVMConfigFlow,
+    SSLCertificateChanged,
+    validate_input,
+)
+from custom_components.nanokvm.const import (
+    CONF_SSL_FINGERPRINT,
+    CONF_USE_STATIC_HOST,
+    DEFAULT_PASSWORD,
+    DEFAULT_USERNAME,
+    INTEGRATION_TITLE,
+)
+
+
+@dataclass(slots=True)
+class ClientScenario:
+    """Script one fake NanoKVM client's authentication and info behavior."""
+
+    auth_error: Exception | None = None
+    info_error: Exception | None = None
+    device_key: object = "device-key"
+
+
+class ScriptedClient:
+    """Minimal async client whose instances consume configured scenarios."""
+
+    scenarios: list[ClientScenario] = []
+    instances: list[ScriptedClient] = []
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        ssl_fingerprint: str | None = None,
+        **_: object,
+    ) -> None:
+        if not self.scenarios:
+            raise AssertionError(f"No client scenario configured for {url}")
+        self.scenario = self.scenarios.pop(0)
+        self.url = URL(url)
+        self.ssl_fingerprint = ssl_fingerprint
+        self.authenticate_calls: list[tuple[str, str]] = []
+        self.entered = False
+        self.exited = False
+        self.instances.append(self)
+
+    async def __aenter__(self) -> ScriptedClient:
+        """Enter the fake client context."""
+        self.entered = True
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        """Exit the fake client context."""
+        self.exited = True
+
+    async def authenticate(self, username: str, password: str) -> None:
+        """Record credentials and raise the scripted authentication error."""
+        self.authenticate_calls.append((username, password))
+        if self.scenario.auth_error is not None:
+            raise self.scenario.auth_error
+
+    async def get_info(self) -> SimpleNamespace:
+        """Return device identity or raise the scripted info error."""
+        if self.scenario.info_error is not None:
+            raise self.scenario.info_error
+        return SimpleNamespace(device_key=self.scenario.device_key)
+
+
+@pytest.fixture
+def install_client(monkeypatch: pytest.MonkeyPatch):
+    """Install a clean scripted client and return its scenario setter."""
+
+    def install(*scenarios: ClientScenario) -> type[ScriptedClient]:
+        ScriptedClient.scenarios = list(scenarios)
+        ScriptedClient.instances = []
+        monkeypatch.setattr(config_flow_module, "NanoKVMClient", ScriptedClient)
+        return ScriptedClient
+
+    return install
+
+
+@pytest.fixture
+def flow(hass_mock: MagicMock) -> NanoKVMConfigFlow:
+    """Return a config flow attached to the shared Home Assistant boundary mock."""
+    config_flow = NanoKVMConfigFlow()
+    config_flow.hass = hass_mock
+    # FlowManager sets a mutable per-flow context before invoking any step.
+    config_flow.context = {"source": "user"}
+    return config_flow
+
+
+def _connection_data(host: str = "nanokvm.local") -> dict[str, Any]:
+    """Return complete config-flow connection input."""
+    return {
+        CONF_HOST: host,
+        CONF_USERNAME: "operator",
+        CONF_PASSWORD: "secret",
+    }
+
+
+def _fingerprint_error() -> aiohttp.ServerFingerprintMismatch:
+    """Return a realistic pinned-certificate mismatch."""
+    return aiohttp.ServerFingerprintMismatch(b"expected", b"received", "nano", 443)
+
+
+@pytest.mark.asyncio
+async def test_validate_input_returns_string_device_key_and_closes_client(
+    install_client,
+) -> None:
+    """Successful validation authenticates once and returns a stable string ID."""
+    client_type = install_client(ClientScenario(device_key=12345))
+
+    assert await validate_input(_connection_data()) == "12345"
+    assert len(client_type.instances) == 1
+    client = client_type.instances[0]
+    assert client.url == URL("http://nanokvm.local/api/")
+    assert client.authenticate_calls == [("operator", "secret")]
+    assert client.entered is True
+    assert client.exited is True
+
+
+@pytest.mark.asyncio
+async def test_validate_input_uses_fingerprint_for_explicit_https(
+    install_client,
+) -> None:
+    """Explicit HTTPS validation passes the stored pin to its only client."""
+    client_type = install_client(ClientScenario())
+    data = _connection_data("https://nanokvm.local")
+    data[CONF_SSL_FINGERPRINT] = "AA11"
+
+    assert await validate_input(data) == "device-key"
+    assert len(client_type.instances) == 1
+    assert client_type.instances[0].ssl_fingerprint == "AA11"
+
+
+@pytest.mark.asyncio
+async def test_validate_input_maps_authentication_failure_without_fallback(
+    install_client,
+) -> None:
+    """Invalid credentials are terminal and map to the flow's auth error."""
+    client_type = install_client(
+        ClientScenario(auth_error=NanoKVMAuthenticationFailure("invalid")),
+        ClientScenario(),
+    )
+
+    with pytest.raises(InvalidAuth):
+        await validate_input(_connection_data())
+
+    assert len(client_type.instances) == 1
+
+
+@pytest.mark.asyncio
+async def test_validate_input_http_certificate_error_falls_back_to_https(
+    install_client,
+) -> None:
+    """A TLS error reached through HTTP redirection tries direct HTTPS next."""
+    client_type = install_client(
+        ClientScenario(auth_error=_fingerprint_error()),
+        ClientScenario(device_key="https-device"),
+    )
+
+    assert await validate_input(_connection_data()) == "https-device"
+    assert [client.url.scheme for client in client_type.instances] == ["http", "https"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "certificate_error",
+    [
+        _fingerprint_error(),
+        aiohttp.ClientConnectorCertificateError(None, ValueError("certificate")),
+    ],
+)
+async def test_validate_input_https_certificate_error_requests_confirmation(
+    install_client,
+    certificate_error: Exception,
+) -> None:
+    """A final HTTPS certificate failure maps to the SSL confirmation flow."""
+    install_client(ClientScenario(auth_error=certificate_error))
+
+    with pytest.raises(SSLCertificateChanged):
+        await validate_input(_connection_data("https://nanokvm.local"))
+
+
+@pytest.mark.asyncio
+async def test_validate_input_exhausted_connection_candidates_cannot_connect(
+    install_client,
+) -> None:
+    """Connection failures exhaust both transports before mapping cannot-connect."""
+    client_type = install_client(
+        ClientScenario(auth_error=aiohttp.ClientConnectionError("http unavailable")),
+        ClientScenario(auth_error=aiohttp.ClientConnectionError("https unavailable")),
+    )
+
+    with pytest.raises(CannotConnect) as error:
+        await validate_input(_connection_data())
+
+    assert isinstance(error.value.__cause__, aiohttp.ClientConnectionError)
+    assert [client.url.scheme for client in client_type.instances] == ["http", "https"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        asyncio.TimeoutError(),
+        aiohttp.ClientPayloadError("invalid payload"),
+        NanoKVMError("api failure"),
+    ],
+)
+async def test_validate_input_non_connection_errors_stop_transport_fallback(
+    install_client,
+    error: Exception,
+) -> None:
+    """Timeout, response, and library errors do not probe another transport."""
+    client_type = install_client(ClientScenario(info_error=error), ClientScenario())
+
+    with pytest.raises(CannotConnect) as flow_error:
+        await validate_input(_connection_data())
+
+    assert flow_error.value.__cause__ is error
+    assert len(client_type.instances) == 1
+
+
+def test_flow_initial_state_and_fingerprint_formatting(flow: NanoKVMConfigFlow) -> None:
+    """A new flow has no staged data and formats certificate hashes for display."""
+    assert flow.data == {}
+    assert flow._discovered_fingerprint is None
+    assert flow._ssl_return_step is None
+    assert flow._format_fingerprint("AABB01") == "AA:BB:01"
+
+
+def test_get_reauth_entry_returns_context_entry(
+    flow: NanoKVMConfigFlow,
+    config_entry_mock: MagicMock,
+) -> None:
+    """Reauth resolves its entry through the context entry ID."""
+    flow.context = {"source": "reauth", "entry_id": config_entry_mock.entry_id}
+    flow.hass.config_entries.async_get_entry.return_value = config_entry_mock
+
+    assert flow._get_reauth_entry() is config_entry_mock
+
+
+def test_get_reauth_entry_rejects_missing_entry(flow: NanoKVMConfigFlow) -> None:
+    """A stale reauth context fails explicitly instead of using missing data."""
+    flow.context = {"source": "reauth", "entry_id": "missing"}
+    flow.hass.config_entries.async_get_entry.return_value = None
+
+    with pytest.raises(RuntimeError, match="missing NanoKVM entry"):
+        flow._get_reauth_entry()
+
+
+def test_find_matching_entry_returns_first_match_or_none(
+    flow: NanoKVMConfigFlow,
+) -> None:
+    """Legacy and device-key matching scans current entries in order."""
+    first = SimpleNamespace(unique_id="first")
+    match = SimpleNamespace(unique_id="device-key")
+    flow._async_current_entries = MagicMock(return_value=[first, match])
+
+    assert flow._async_find_matching_entry("legacy", "device-key") is match
+    assert flow._async_find_matching_entry("absent") is None
+
+
+def test_existing_static_entry_aborts_without_host_update(
+    flow: NanoKVMConfigFlow,
+    config_entry_mock: MagicMock,
+) -> None:
+    """Static entries ignore discovery and keep their configured host."""
+    config_entry_mock.data[CONF_USE_STATIC_HOST] = True
+
+    result = flow._async_handle_existing_entry(
+        config_entry_mock,
+        "192.0.2.20",
+        device_key="new-key",
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.parametrize(
+    ("current_unique_id", "device_key", "expected_unique_id"),
+    [
+        ("legacy.local.", "device-key", "device-key"),
+        ("device-key", "device-key", None),
+        ("legacy.local.", None, None),
+    ],
+)
+def test_existing_dynamic_entry_updates_discovered_host_and_optional_unique_id(
+    flow: NanoKVMConfigFlow,
+    config_entry_mock: MagicMock,
+    current_unique_id: str,
+    device_key: str | None,
+    expected_unique_id: str | None,
+) -> None:
+    """Verified dynamic discovery refreshes the host and migrates legacy IDs."""
+    config_entry_mock.unique_id = current_unique_id
+    config_entry_mock.data[CONF_USE_STATIC_HOST] = False
+    flow.async_update_reload_and_abort = MagicMock(return_value={"updated": True})
+
+    result = flow._async_handle_existing_entry(
+        config_entry_mock,
+        "192.0.2.20",
+        device_key=device_key,
+    )
+
+    assert result == {"updated": True}
+    kwargs = flow.async_update_reload_and_abort.call_args.kwargs
+    assert kwargs["data_updates"] == {CONF_HOST: "192.0.2.20"}
+    assert kwargs["reason"] == "already_configured"
+    assert kwargs["reload_even_if_entry_is_unchanged"] is False
+    assert kwargs.get("unique_id") == expected_unique_id
+
+
+def test_existing_dynamic_entry_with_unchanged_host_still_uses_reload_helper(
+    flow: NanoKVMConfigFlow,
+    config_entry_mock: MagicMock,
+) -> None:
+    """Unchanged discovery uses the helper's no-reload-if-unchanged contract."""
+    config_entry_mock.data[CONF_USE_STATIC_HOST] = False
+    flow.async_update_reload_and_abort = MagicMock(return_value={"updated": True})
+
+    assert flow._async_handle_existing_entry(
+        config_entry_mock,
+        config_entry_mock.data[CONF_HOST],
+    ) == {"updated": True}
+    assert (
+        flow.async_update_reload_and_abort.call_args.kwargs[
+            "reload_even_if_entry_is_unchanged"
+        ]
+        is False
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("static_host", [None, False, True])
+async def test_add_device_sets_unique_id_defaults_and_creates_entry(
+    flow: NanoKVMConfigFlow,
+    static_host: bool | None,
+) -> None:
+    """Adding a device records identity and persists an explicit discovery policy."""
+    flow.async_set_unique_id = AsyncMock()
+    flow._abort_if_unique_id_configured = MagicMock()
+    data = _connection_data()
+    if static_host is not None:
+        data[CONF_USE_STATIC_HOST] = static_host
+
+    result = await flow.add_device("device-key", data)
+
+    flow.async_set_unique_id.assert_awaited_once_with("device-key")
+    flow._abort_if_unique_id_configured.assert_called_once_with()
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == INTEGRATION_TITLE
+    assert result["data"][CONF_USE_STATIC_HOST] is bool(static_host)
+
+
+@pytest.mark.asyncio
+async def test_fetch_ssl_fingerprint_routes_new_and_changed_certificates(
+    flow: NanoKVMConfigFlow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fingerprint probing chooses first-trust or changed-certificate confirmation."""
+    fetch = AsyncMock(side_effect=["AABB", "CCDD"])
+    monkeypatch.setattr(config_flow_module, "async_fetch_remote_fingerprint", fetch)
+    flow.data = {CONF_HOST: "nanokvm.local"}
+
+    first = await flow._async_fetch_and_redirect_ssl("confirm")
+    assert first["step_id"] == "ssl_fingerprint"
+    assert first["description_placeholders"]["fingerprint"] == "AA:BB"
+
+    flow.data[CONF_SSL_FINGERPRINT] = "AABB"
+    changed = await flow._async_fetch_and_redirect_ssl("reauth_finish")
+    assert changed["step_id"] == "ssl_fingerprint_changed"
+    assert changed["description_placeholders"] == {
+        "host": "nanokvm.local",
+        "old_fingerprint": "AA:BB",
+        "new_fingerprint": "CC:DD",
+    }
+    assert fetch.await_args_list[0].args == ("https://nanokvm.local/api/",)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("return_step", "method_name"),
+    [
+        ("confirm", "async_step_confirm"),
+        ("auth", "async_step_auth"),
+        ("reauth_finish", "async_step_reauth_finish"),
+    ],
+)
+async def test_accepting_new_fingerprint_resumes_saved_step(
+    flow: NanoKVMConfigFlow,
+    return_step: str,
+    method_name: str,
+) -> None:
+    """Certificate acceptance stores the pin and resumes the interrupted step."""
+    flow.data = {CONF_HOST: "nanokvm.local"}
+    flow._discovered_fingerprint = "AABB"
+    flow._ssl_return_step = return_step
+    resumed = AsyncMock(return_value={"resumed": return_step})
+    setattr(flow, method_name, resumed)
+
+    result = await flow.async_step_ssl_fingerprint({})
+
+    assert result == {"resumed": return_step}
+    assert flow.data[CONF_SSL_FINGERPRINT] == "AABB"
+    assert flow._ssl_return_step is None
+    resumed.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_accepting_fingerprint_without_saved_step_returns_form(
+    flow: NanoKVMConfigFlow,
+) -> None:
+    """A defensive missing return target leaves the flow on certificate confirmation."""
+    flow.data = {CONF_HOST: "nanokvm.local"}
+    flow._discovered_fingerprint = "AABB"
+    flow._ssl_return_step = None
+
+    result = await flow.async_step_ssl_fingerprint({})
+
+    assert result["step_id"] == "ssl_fingerprint"
+    assert flow.data[CONF_SSL_FINGERPRINT] == "AABB"
+
+
+@pytest.mark.asyncio
+async def test_accepting_changed_fingerprint_finishes_reauth(
+    flow: NanoKVMConfigFlow,
+) -> None:
+    """Changed-certificate acceptance replaces the pin before reauth validation."""
+    flow.data = {CONF_HOST: "nanokvm.local", CONF_SSL_FINGERPRINT: "OLD"}
+    flow._discovered_fingerprint = "NEW"
+    flow.async_step_reauth_finish = AsyncMock(return_value={"reauth": True})
+
+    result = await flow.async_step_ssl_fingerprint_changed({})
+
+    assert result == {"reauth": True}
+    assert flow.data[CONF_SSL_FINGERPRINT] == "NEW"
+    flow.async_step_reauth_finish.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_user_step_shows_schema_without_input(flow: NanoKVMConfigFlow) -> None:
+    """The first form requests host and defaults dynamic discovery on."""
+    result = await flow.async_step_user()
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["data_schema"]({CONF_HOST: "nano"}) == {
+        CONF_HOST: "nano",
+        CONF_USE_STATIC_HOST: False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_user_step_success_stages_defaults_and_requests_confirmation(
+    flow: NanoKVMConfigFlow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default credentials that work stage complete data before confirmation."""
+    validation = AsyncMock(return_value="device-key")
+    monkeypatch.setattr(config_flow_module, "validate_input", validation)
+
+    result = await flow.async_step_user(
+        {CONF_HOST: "nanokvm.local", CONF_USE_STATIC_HOST: True}
+    )
+
+    assert result["step_id"] == "confirm"
+    assert flow.data == {
+        CONF_HOST: "nanokvm.local",
+        CONF_USE_STATIC_HOST: True,
+        CONF_USERNAME: DEFAULT_USERNAME,
+        CONF_PASSWORD: DEFAULT_PASSWORD,
+    }
+    validation.assert_awaited_once_with(flow.data)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "expected_error"),
+    [
+        (CannotConnect(), "cannot_connect"),
+        (RuntimeError("unexpected"), "unknown"),
+    ],
+)
+async def test_user_step_connection_and_unknown_errors_stay_on_form(
+    flow: NanoKVMConfigFlow,
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+    expected_error: str,
+) -> None:
+    """Recoverable setup failures are rendered on the initial form."""
+    monkeypatch.setattr(
+        config_flow_module,
+        "validate_input",
+        AsyncMock(side_effect=error),
+    )
+
+    result = await flow.async_step_user({CONF_HOST: "nanokvm.local"})
+
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": expected_error}
+
+
+@pytest.mark.asyncio
+async def test_user_step_invalid_default_credentials_routes_to_auth(
+    flow: NanoKVMConfigFlow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A detected device with changed credentials asks the user to authenticate."""
+    monkeypatch.setattr(
+        config_flow_module,
+        "validate_input",
+        AsyncMock(side_effect=InvalidAuth()),
+    )
+
+    result = await flow.async_step_user({CONF_HOST: "nanokvm.local"})
+
+    assert result["step_id"] == "auth"
+    assert flow.data == {CONF_HOST: "nanokvm.local"}
+
+
+@pytest.mark.asyncio
+async def test_user_step_certificate_error_routes_to_ssl_confirmation(
+    flow: NanoKVMConfigFlow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A self-signed certificate is fingerprinted before device confirmation."""
+    monkeypatch.setattr(
+        config_flow_module,
+        "validate_input",
+        AsyncMock(side_effect=SSLCertificateChanged()),
+    )
+    fetch = AsyncMock(return_value="AABB")
+    monkeypatch.setattr(config_flow_module, "async_fetch_remote_fingerprint", fetch)
+
+    result = await flow.async_step_user({CONF_HOST: "nanokvm.local"})
+
+    assert result["step_id"] == "ssl_fingerprint"
+    assert flow._ssl_return_step == "confirm"
+    assert flow.data[CONF_USERNAME] == DEFAULT_USERNAME
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "expected_step", "expected_error"),
+    [
+        (CannotConnect(), "confirm", "cannot_connect"),
+        (RuntimeError("unexpected"), "confirm", "unknown"),
+    ],
+)
+async def test_confirm_step_errors_remain_on_confirmation(
+    flow: NanoKVMConfigFlow,
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+    expected_step: str,
+    expected_error: str,
+) -> None:
+    """Confirmation revalidation reports connection and unexpected failures."""
+    flow.data = _connection_data()
+    monkeypatch.setattr(
+        config_flow_module,
+        "validate_input",
+        AsyncMock(side_effect=error),
+    )
+
+    result = await flow.async_step_confirm({})
+
+    assert result["step_id"] == expected_step
+    assert result["errors"] == {"base": expected_error}
+
+
+@pytest.mark.asyncio
+async def test_confirm_step_auth_change_routes_to_auth(
+    flow: NanoKVMConfigFlow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Credentials changed during confirmation return the user to auth."""
+    flow.data = _connection_data()
+    monkeypatch.setattr(
+        config_flow_module,
+        "validate_input",
+        AsyncMock(side_effect=InvalidAuth()),
+    )
+
+    assert (await flow.async_step_confirm({}))["step_id"] == "auth"
+
+
+@pytest.mark.asyncio
+async def test_confirm_step_certificate_change_repeats_ssl_confirmation(
+    flow: NanoKVMConfigFlow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A certificate change during confirmation refreshes the displayed pin."""
+    flow.data = _connection_data()
+    monkeypatch.setattr(
+        config_flow_module,
+        "validate_input",
+        AsyncMock(side_effect=SSLCertificateChanged()),
+    )
+    monkeypatch.setattr(
+        config_flow_module,
+        "async_fetch_remote_fingerprint",
+        AsyncMock(return_value="AABB"),
+    )
+
+    result = await flow.async_step_confirm({})
+
+    assert result["step_id"] == "ssl_fingerprint"
+    assert flow._ssl_return_step == "confirm"
+
+
+@pytest.mark.asyncio
+async def test_confirm_step_success_adds_staged_device(
+    flow: NanoKVMConfigFlow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Successful confirmation delegates final entry creation with staged data."""
+    flow.data = _connection_data()
+    monkeypatch.setattr(
+        config_flow_module,
+        "validate_input",
+        AsyncMock(return_value="device-key"),
+    )
+    flow.add_device = AsyncMock(return_value={"created": True})
+
+    assert await flow.async_step_confirm({}) == {"created": True}
+    flow.add_device.assert_awaited_once_with("device-key", flow.data)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "expected_error"),
+    [
+        (CannotConnect(), "cannot_connect"),
+        (InvalidAuth(), "invalid_auth"),
+        (RuntimeError("unexpected"), "unknown"),
+    ],
+)
+async def test_auth_step_reports_validation_errors(
+    flow: NanoKVMConfigFlow,
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+    expected_error: str,
+) -> None:
+    """Credential validation maps its supported errors onto the auth form."""
+    flow.data = {CONF_HOST: "nanokvm.local"}
+    monkeypatch.setattr(
+        config_flow_module,
+        "validate_input",
+        AsyncMock(side_effect=error),
+    )
+
+    result = await flow.async_step_auth(
+        {CONF_USERNAME: "operator", CONF_PASSWORD: "secret"}
+    )
+
+    assert result["step_id"] == "auth"
+    assert result["errors"] == {"base": expected_error}
+
+
+@pytest.mark.asyncio
+async def test_auth_step_success_merges_credentials_and_adds_device(
+    flow: NanoKVMConfigFlow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Successful authentication preserves host data and stores entered credentials."""
+    flow.data = {CONF_HOST: "nanokvm.local", CONF_USE_STATIC_HOST: True}
+    monkeypatch.setattr(
+        config_flow_module,
+        "validate_input",
+        AsyncMock(return_value="device-key"),
+    )
+    flow.add_device = AsyncMock(return_value={"created": True})
+    credentials = {CONF_USERNAME: "operator", CONF_PASSWORD: "secret"}
+
+    assert await flow.async_step_auth(credentials) == {"created": True}
+    flow.add_device.assert_awaited_once_with(
+        "device-key",
+        flow.data | credentials,
+    )
+
+
+@pytest.mark.asyncio
+async def test_auth_step_certificate_error_resumes_auth_after_confirmation(
+    flow: NanoKVMConfigFlow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TLS confirmation during auth retains the credentials being validated."""
+    flow.data = {CONF_HOST: "nanokvm.local"}
+    monkeypatch.setattr(
+        config_flow_module,
+        "validate_input",
+        AsyncMock(side_effect=SSLCertificateChanged()),
+    )
+    monkeypatch.setattr(
+        config_flow_module,
+        "async_fetch_remote_fingerprint",
+        AsyncMock(return_value="AABB"),
+    )
+
+    result = await flow.async_step_auth(
+        {CONF_USERNAME: "operator", CONF_PASSWORD: "secret"}
+    )
+
+    assert result["step_id"] == "ssl_fingerprint"
+    assert flow._ssl_return_step == "auth"
+    assert flow.data[CONF_USERNAME] == "operator"
+
+
+def _prepare_reauth(
+    flow: NanoKVMConfigFlow,
+    entry: MagicMock,
+) -> None:
+    """Attach a config entry to a flow's reauthentication context."""
+    entry.title = "NanoKVM"
+    flow.context = {"source": "reauth", "entry_id": entry.entry_id}
+    flow.hass.config_entries.async_get_entry.return_value = entry
+
+
+@pytest.mark.asyncio
+async def test_reauth_probe_routes_to_credential_form(
+    flow: NanoKVMConfigFlow,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A normal reauth probe proceeds to the credential form with stored data."""
+    _prepare_reauth(flow, config_entry_mock)
+    monkeypatch.setattr(
+        config_flow_module,
+        "validate_input",
+        AsyncMock(side_effect=InvalidAuth()),
+    )
+
+    result = await flow.async_step_reauth(dict(config_entry_mock.data))
+
+    assert result["step_id"] == "reauth_confirm"
+    assert result["description_placeholders"]["name"] == "nanokvm.local"
+    assert flow.data == config_entry_mock.data
+
+
+@pytest.mark.asyncio
+async def test_reauth_probe_certificate_change_routes_to_changed_confirmation(
+    flow: NanoKVMConfigFlow,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reauth detects a changed stored certificate before asking for credentials."""
+    config_entry_mock.data[CONF_SSL_FINGERPRINT] = "OLD"
+    _prepare_reauth(flow, config_entry_mock)
+    monkeypatch.setattr(
+        config_flow_module,
+        "validate_input",
+        AsyncMock(side_effect=SSLCertificateChanged()),
+    )
+    monkeypatch.setattr(
+        config_flow_module,
+        "async_fetch_remote_fingerprint",
+        AsyncMock(return_value="NEW"),
+    )
+
+    result = await flow.async_step_reauth({})
+
+    assert result["step_id"] == "ssl_fingerprint_changed"
+    assert flow._ssl_return_step == "reauth_finish"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "expected_error"),
+    [
+        (CannotConnect(), "cannot_connect"),
+        (InvalidAuth(), "invalid_auth"),
+        (SSLCertificateChanged(), "ssl_certificate_changed"),
+        (RuntimeError("unexpected"), "unknown"),
+    ],
+)
+async def test_reauth_confirm_maps_validation_errors(
+    flow: NanoKVMConfigFlow,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+    expected_error: str,
+) -> None:
+    """Updated credentials report each supported validation failure."""
+    _prepare_reauth(flow, config_entry_mock)
+    monkeypatch.setattr(
+        config_flow_module,
+        "validate_input",
+        AsyncMock(side_effect=error),
+    )
+
+    result = await flow.async_step_reauth_confirm(
+        {CONF_USERNAME: "new-user", CONF_PASSWORD: "new-password"}
+    )
+
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": expected_error}
+    assert flow.data[CONF_USERNAME] == "new-user"
+
+
+@pytest.mark.asyncio
+async def test_reauth_confirm_success_finishes_entry_update(
+    flow: NanoKVMConfigFlow,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Valid replacement credentials delegate the final reauth update."""
+    _prepare_reauth(flow, config_entry_mock)
+    monkeypatch.setattr(
+        config_flow_module,
+        "validate_input",
+        AsyncMock(return_value="new-device-key"),
+    )
+    flow._async_finish_reauth = AsyncMock(return_value={"updated": True})
+
+    assert await flow.async_step_reauth_confirm(
+        {CONF_USERNAME: "new-user", CONF_PASSWORD: "new-password"}
+    ) == {"updated": True}
+    flow._async_finish_reauth.assert_awaited_once_with(
+        config_entry_mock,
+        "new-device-key",
+    )
+
+
+@pytest.mark.asyncio
+async def test_reauth_finish_invalid_auth_returns_to_credentials(
+    flow: NanoKVMConfigFlow,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An accepted certificate does not hide an independent credential failure."""
+    _prepare_reauth(flow, config_entry_mock)
+    flow.data = dict(config_entry_mock.data)
+    monkeypatch.setattr(
+        config_flow_module,
+        "validate_input",
+        AsyncMock(side_effect=InvalidAuth()),
+    )
+    flow.async_step_reauth_confirm = AsyncMock(return_value={"credentials": True})
+
+    assert await flow.async_step_reauth_finish() == {"credentials": True}
+    flow.async_step_reauth_confirm.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error", [CannotConnect(), SSLCertificateChanged()])
+async def test_reauth_finish_connection_failures_abort(
+    flow: NanoKVMConfigFlow,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+) -> None:
+    """Failure after certificate acceptance terminates reauth cleanly."""
+    _prepare_reauth(flow, config_entry_mock)
+    flow.data = dict(config_entry_mock.data)
+    monkeypatch.setattr(
+        config_flow_module,
+        "validate_input",
+        AsyncMock(side_effect=error),
+    )
+
+    result = await flow.async_step_reauth_finish()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+
+@pytest.mark.asyncio
+async def test_reauth_finish_success_updates_entry(
+    flow: NanoKVMConfigFlow,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Successful post-certificate validation completes the reauth update."""
+    _prepare_reauth(flow, config_entry_mock)
+    flow.data = dict(config_entry_mock.data)
+    monkeypatch.setattr(
+        config_flow_module,
+        "validate_input",
+        AsyncMock(return_value="device-key"),
+    )
+    flow._async_finish_reauth = AsyncMock(return_value={"updated": True})
+
+    assert await flow.async_step_reauth_finish() == {"updated": True}
+    flow._async_finish_reauth.assert_awaited_once_with(
+        config_entry_mock,
+        "device-key",
+    )
+
+
+@pytest.mark.asyncio
+async def test_finish_reauth_rejects_device_owned_by_another_entry(
+    flow: NanoKVMConfigFlow,
+    config_entry_mock: MagicMock,
+) -> None:
+    """Reauth cannot migrate an entry onto another configured device identity."""
+    other_entry = SimpleNamespace(entry_id="other-entry", unique_id="device-key")
+    flow.data = dict(config_entry_mock.data)
+    flow.async_set_unique_id = AsyncMock()
+    flow._async_find_matching_entry = MagicMock(return_value=other_entry)
+
+    result = await flow._async_finish_reauth(config_entry_mock, "device-key")
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("device_key", ["test-device", "new-device-key"])
+async def test_finish_reauth_updates_credentials_pin_and_identity_when_needed(
+    flow: NanoKVMConfigFlow,
+    config_entry_mock: MagicMock,
+    device_key: str,
+) -> None:
+    """Successful reauth updates credentials and migrates a changed device key."""
+    flow.data = {
+        **config_entry_mock.data,
+        CONF_USERNAME: "new-user",
+        CONF_PASSWORD: "new-password",
+        CONF_SSL_FINGERPRINT: "AABB",
+    }
+    flow.async_set_unique_id = AsyncMock()
+    flow._async_find_matching_entry = MagicMock(return_value=config_entry_mock)
+    flow.async_update_reload_and_abort = MagicMock(return_value={"updated": True})
+
+    assert await flow._async_finish_reauth(config_entry_mock, device_key) == {
+        "updated": True
+    }
+    kwargs = flow.async_update_reload_and_abort.call_args.kwargs
+    assert kwargs["reason"] == "reauth_successful"
+    assert kwargs["data_updates"] == {
+        CONF_USERNAME: "new-user",
+        CONF_PASSWORD: "new-password",
+        CONF_SSL_FINGERPRINT: "AABB",
+    }
+    assert kwargs.get("unique_id") == (
+        None if device_key == config_entry_mock.unique_id else device_key
+    )
+
+
+def _discovery_info() -> SimpleNamespace:
+    """Return a zeroconf discovery payload."""
+    return SimpleNamespace(hostname="nano-kvm.local.", host="192.0.2.20")
+
+
+def _prepare_new_discovery(flow: NanoKVMConfigFlow) -> None:
+    """Install Home Assistant boundary mocks used by new discovery flows."""
+    flow.context = {"source": "zeroconf"}
+    flow.async_set_unique_id = AsyncMock()
+    flow._abort_if_unique_id_configured = MagicMock()
+    flow._async_find_matching_entry = MagicMock(return_value=None)
+    flow.async_step_user = AsyncMock(return_value={"user": True})
+
+
+@pytest.mark.asyncio
+async def test_zeroconf_verified_existing_entry_updates_by_device_key(
+    flow: NanoKVMConfigFlow,
+    config_entry_mock: MagicMock,
+    install_client,
+) -> None:
+    """Authenticated discovery updates an existing device using verified identity."""
+    install_client(ClientScenario(device_key="verified-key"))
+    flow.async_set_unique_id = AsyncMock()
+    flow._async_find_matching_entry = MagicMock(return_value=config_entry_mock)
+    flow._async_handle_existing_entry = MagicMock(return_value={"updated": True})
+
+    assert await flow.async_step_zeroconf(_discovery_info()) == {"updated": True}
+    flow._async_find_matching_entry.assert_called_once_with(
+        "verified-key",
+        "nano-kvm.local.",
+    )
+    flow._async_handle_existing_entry.assert_called_once_with(
+        config_entry_mock,
+        "192.0.2.20",
+        device_key="verified-key",
+    )
+
+
+@pytest.mark.asyncio
+async def test_zeroconf_new_default_device_routes_to_user_confirmation(
+    flow: NanoKVMConfigFlow,
+    install_client,
+) -> None:
+    """A new default-credential device stages its discovered host for setup."""
+    client_type = install_client(ClientScenario(device_key="verified-key"))
+    _prepare_new_discovery(flow)
+
+    assert await flow.async_step_zeroconf(_discovery_info()) == {"user": True}
+    flow.async_set_unique_id.assert_awaited_once_with("verified-key")
+    flow._abort_if_unique_id_configured.assert_called_once_with()
+    flow.async_step_user.assert_awaited_once_with(user_input={CONF_HOST: "192.0.2.20"})
+    assert flow.context["title_placeholders"] == {"name": "nano-kvm.local"}
+    assert client_type.instances[0].authenticate_calls == [
+        (DEFAULT_USERNAME, DEFAULT_PASSWORD)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_zeroconf_auth_required_uses_legacy_identity_for_new_flow(
+    flow: NanoKVMConfigFlow,
+    install_client,
+) -> None:
+    """Auth-required discovery uses normalized mDNS identity until login succeeds."""
+    install_client(
+        ClientScenario(auth_error=NanoKVMAuthenticationFailure("credentials changed"))
+    )
+    _prepare_new_discovery(flow)
+
+    assert await flow.async_step_zeroconf(_discovery_info()) == {"user": True}
+    flow.async_set_unique_id.assert_awaited_once_with("nano-kvm.local.")
+    flow.async_step_user.assert_awaited_once_with(user_input={CONF_HOST: "192.0.2.20"})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        aiohttp.ClientConnectionError("unreachable"),
+        asyncio.TimeoutError(),
+        NanoKVMError("not a NanoKVM"),
+    ],
+)
+async def test_zeroconf_connection_errors_abort_discovery(
+    flow: NanoKVMConfigFlow,
+    install_client,
+    error: Exception,
+) -> None:
+    """Unverified network and API failures are ignored as invalid discovery."""
+    install_client(ClientScenario(auth_error=error))
+
+    result = await flow.async_step_zeroconf(_discovery_info())
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+
+@pytest.mark.asyncio
+async def test_zeroconf_duplicate_identity_propagates_framework_abort(
+    flow: NanoKVMConfigFlow,
+    install_client,
+) -> None:
+    """The Home Assistant duplicate guard terminates a new discovery flow."""
+    install_client(ClientScenario(device_key="duplicate-key"))
+    _prepare_new_discovery(flow)
+    flow._abort_if_unique_id_configured.side_effect = AbortFlow("already_configured")
+
+    with pytest.raises(AbortFlow, match="already_configured"):
+        await flow.async_step_zeroconf(_discovery_info())

--- a/tests/core/test_coordinator.py
+++ b/tests/core/test_coordinator.py
@@ -1,0 +1,1215 @@
+"""Behavior tests for the NanoKVM data update coordinator."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, call
+
+import aiohttp
+import pytest
+from yarl import URL
+
+from homeassistant.const import CONF_HOST
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from nanokvm.client import (
+    NanoKVMApiError,
+    NanoKVMAuthenticationFailure,
+    NanoKVMClient,
+    NanoKVMError,
+    NanoKVMNotSupportedError,
+)
+from nanokvm.models import (
+    GetCdRomRsp,
+    GetGpioRsp,
+    GetHardwareRsp,
+    GetHdmiCaptureRsp,
+    GetHdmiPassthroughRsp,
+    GetHdmiStateRsp,
+    GetHidModeRsp,
+    GetHostnameRsp,
+    GetInfoRsp,
+    GetLcdTimeFormatRsp,
+    GetLedStripRsp,
+    GetLowPowerRsp,
+    GetMdnsStateRsp,
+    GetMountedImageRsp,
+    GetMouseJigglerRsp,
+    GetOLEDRsp,
+    GetSSHStateRsp,
+    GetStaticIPRsp,
+    GetTailscaleStatusRsp,
+    GetTimeStatusRsp,
+    GetVersionRsp,
+    GetVirtualDeviceRsp,
+    GetWifiRsp,
+    HidMode,
+    HWVersion,
+    IPInfo,
+    LcdTimeFormat,
+    MouseJigglerMode,
+    TailscaleState,
+)
+
+import custom_components.nanokvm.coordinator as coordinator_module
+from custom_components.nanokvm.const import (
+    CONF_SSL_FINGERPRINT,
+    SIGNAL_NEW_MEDIA_ENTITIES,
+    SIGNAL_NEW_NETWORK_ENTITIES,
+    SIGNAL_NEW_SSH_SENSORS,
+    SIGNAL_NEW_SSH_SWITCHES,
+)
+from custom_components.nanokvm.coordinator import (
+    NanoKVMDataUpdateCoordinator,
+    _format_timeout_error,
+    _is_auth_failure,
+    _is_invalid_file_content_error,
+)
+from custom_components.nanokvm.ssh_metrics import SSHMetricsSnapshot
+
+
+@pytest.fixture
+def coordinator(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+) -> NanoKVMDataUpdateCoordinator:
+    """Return a coordinator with a mocked device boundary."""
+    client = MagicMock(spec=NanoKVMClient)
+    client.url = URL("http://nanokvm.local/api/")
+    client.token = "token"
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    return NanoKVMDataUpdateCoordinator(
+        hass_mock,
+        config_entry_mock,
+        client=client,
+        username="admin",
+        password="password",
+        device_info=_device_info(),
+    )
+
+
+def _device_info(
+    *,
+    application: str = "2.2.2",
+    ips: list[IPInfo] | None = None,
+) -> GetInfoRsp:
+    """Build a complete NanoKVM device-info response."""
+    return GetInfoRsp(
+        ips=[] if ips is None else ips,
+        mdns="nanokvm.local",
+        image="2026-07-12",
+        application=application,
+        deviceKey="test-device",
+    )
+
+
+def _response_error(status: int) -> aiohttp.ClientResponseError:
+    """Build an aiohttp response error with a printable request URL."""
+    return aiohttp.ClientResponseError(
+        request_info=SimpleNamespace(real_url=URL("http://nanokvm.local/api/vm/info")),
+        history=(),
+        status=status,
+        message="response failure",
+    )
+
+
+def _api_error(
+    *,
+    code: int = -1,
+    message: str = "device error",
+) -> NanoKVMApiError:
+    """Build a NanoKVM API-level error."""
+    return NanoKVMApiError(message, code=code, msg=message)
+
+
+def _candidate_client(
+    url: str,
+    *,
+    authenticate_error: Exception | None = None,
+) -> MagicMock:
+    """Build a candidate transport client."""
+    candidate = MagicMock(spec=NanoKVMClient)
+    candidate.url = URL(url)
+    candidate.token = "candidate-token"
+    candidate.__aenter__ = AsyncMock(return_value=candidate)
+    candidate.__aexit__ = AsyncMock(return_value=None)
+    candidate.authenticate = AsyncMock(side_effect=authenticate_error)
+    return candidate
+
+
+def _configure_required_client_responses(
+    client: MagicMock,
+    *,
+    hardware: HWVersion | None,
+) -> dict[str, object]:
+    """Configure complete core endpoint responses for one hardware model."""
+    responses: dict[str, object] = {
+        "device_info": _device_info(),
+        "hostname_info": GetHostnameRsp(hostname="nano"),
+        "hardware_info": None if hardware is None else GetHardwareRsp(version=hardware),
+        "gpio_info": GetGpioRsp(pwr=True, hdd=False),
+        "virtual_device_info": GetVirtualDeviceRsp(network=True, disk=True),
+        "ssh_state": GetSSHStateRsp(enabled=True),
+        "mdns_state": GetMdnsStateRsp(enabled=True),
+        "hid_mode": GetHidModeRsp(mode=HidMode.NORMAL),
+        "oled_info": GetOLEDRsp(exist=True, sleep=60),
+        "wifi_status": GetWifiRsp(supported=True, connected=True, ssid="lab"),
+        "hdmi_state": GetHdmiStateRsp(enabled=True),
+        "mouse_jiggler_state": GetMouseJigglerRsp(
+            enabled=True,
+            mode=MouseJigglerMode.ABSOLUTE,
+        ),
+        "swap_size": 256,
+        "tailscale_status": GetTailscaleStatusRsp(
+            state=TailscaleState.RUNNING,
+            name="nano",
+            ip="100.64.0.10",
+            account="owner@example.com",
+        ),
+    }
+    client.get_info.return_value = responses["device_info"]
+    client.get_hostname.return_value = responses["hostname_info"]
+    client.get_hardware.return_value = responses["hardware_info"]
+    client.get_gpio.return_value = responses["gpio_info"]
+    client.get_virtual_device_status.return_value = responses["virtual_device_info"]
+    client.get_ssh_state.return_value = responses["ssh_state"]
+    client.get_mdns_state.return_value = responses["mdns_state"]
+    client.get_hid_mode.return_value = responses["hid_mode"]
+    client.get_oled_info.return_value = responses["oled_info"]
+    client.get_wifi_status.return_value = responses["wifi_status"]
+    client.get_hdmi_state.return_value = responses["hdmi_state"]
+    client.get_mouse_jiggler_state.return_value = responses["mouse_jiggler_state"]
+    client.get_swap_size.return_value = responses["swap_size"]
+    client.get_tailscale_status.return_value = responses["tailscale_status"]
+    return responses
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (NanoKVMAuthenticationFailure("invalid"), True),
+        (_response_error(401), True),
+        (_response_error(403), False),
+        (NanoKVMError("other"), False),
+    ],
+)
+def test_auth_failure_classification(error: Exception, expected: bool) -> None:
+    """Only explicit authentication failures and HTTP 401 require reauth."""
+    assert _is_auth_failure(error) is expected
+
+
+def test_invalid_file_content_error_requires_matching_code_and_message() -> None:
+    """The optional OLED-file policy matches the complete API error signature."""
+    matching = _api_error(code=-2, message="invalid file content")
+    wrong_code = _api_error(code=-1, message="invalid file content")
+    wrong_message = _api_error(code=-2, message="other")
+
+    assert _is_invalid_file_content_error(matching) is True
+    assert _is_invalid_file_content_error(wrong_code) is False
+    assert _is_invalid_file_content_error(wrong_message) is False
+    assert _format_timeout_error("testing") == "Timed out testing after 10 seconds"
+
+
+async def test_update_data_retries_then_returns_success(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Transient update failures are retried with the configured delay."""
+    expected = {"ready": True}
+    coordinator._async_fetch_once = AsyncMock(
+        side_effect=[UpdateFailed("first"), UpdateFailed("second"), expected]
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr(coordinator_module.asyncio, "sleep", sleep)
+
+    assert await coordinator._async_update_data() == expected
+    assert coordinator._async_fetch_once.await_count == 3
+    assert sleep.await_args_list == [call(1), call(1)]
+
+
+async def test_update_data_reraises_final_failure(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The third update failure is returned to Home Assistant."""
+    final_error = UpdateFailed("final")
+    coordinator._async_fetch_once = AsyncMock(
+        side_effect=[UpdateFailed("first"), UpdateFailed("second"), final_error]
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr(coordinator_module.asyncio, "sleep", sleep)
+
+    with pytest.raises(UpdateFailed, match="final") as captured:
+        await coordinator._async_update_data()
+
+    assert captured.value is final_error
+    assert sleep.await_count == 2
+
+
+async def test_fetch_once_http_fingerprint_error_can_fail_over(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """An HTTP probe redirected to mismatched TLS may switch transports."""
+    mismatch = aiohttp.ServerFingerprintMismatch(b"expected", b"actual", "nano", 443)
+    expected = {"transport": "https"}
+    coordinator._async_fetch_with_client = AsyncMock(side_effect=[mismatch, expected])
+    coordinator._async_failover_client = AsyncMock(return_value=True)
+
+    assert await coordinator._async_fetch_once() == expected
+    coordinator._async_failover_client.assert_awaited_once_with(mismatch)
+
+
+async def test_fetch_once_https_fingerprint_error_starts_reauthentication(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """A fingerprint change on active HTTPS is an entry-auth failure."""
+    coordinator.client.url = URL("https://nanokvm.local/api/")
+    mismatch = aiohttp.ServerFingerprintMismatch(b"expected", b"actual", "nano", 443)
+    coordinator._async_fetch_with_client = AsyncMock(side_effect=mismatch)
+    coordinator._async_failover_client = AsyncMock()
+
+    with pytest.raises(ConfigEntryAuthFailed, match="SSL certificate changed"):
+        await coordinator._async_fetch_once()
+
+    coordinator._async_failover_client.assert_not_awaited()
+
+
+async def test_fetch_once_connection_failure_without_fallback_is_update_failed(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """An exhausted connection failover remains a retryable update failure."""
+    disconnected = aiohttp.ServerDisconnectedError("gone")
+    coordinator._async_fetch_with_client = AsyncMock(side_effect=disconnected)
+    coordinator._async_failover_client = AsyncMock(return_value=False)
+
+    with pytest.raises(UpdateFailed, match="Error communicating with NanoKVM"):
+        await coordinator._async_fetch_once()
+
+
+async def test_fetch_once_reauthenticates_then_returns_data(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """An expired token is replaced before retrying the fetch once."""
+    expected = {"reauthenticated": True}
+    expired = NanoKVMAuthenticationFailure("expired")
+    coordinator._async_fetch_with_client = AsyncMock(side_effect=[expired, expected])
+    coordinator._async_reauthenticate_client = AsyncMock()
+
+    assert await coordinator._async_fetch_once() == expected
+    coordinator._async_reauthenticate_client.assert_awaited_once_with(expired)
+
+
+@pytest.mark.parametrize(
+    ("second_error", "expected_exception", "message"),
+    [
+        (
+            _response_error(401),
+            ConfigEntryAuthFailed,
+            "Stored NanoKVM credentials are no longer valid",
+        ),
+        (_response_error(500), UpdateFailed, "HTTP error with NanoKVM"),
+    ],
+)
+async def test_fetch_once_maps_error_after_reauthentication(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    second_error: Exception,
+    expected_exception: type[Exception],
+    message: str,
+) -> None:
+    """The retry after reauthentication preserves auth and HTTP contracts."""
+    coordinator._async_fetch_with_client = AsyncMock(
+        side_effect=[NanoKVMAuthenticationFailure("expired"), second_error]
+    )
+    coordinator._async_reauthenticate_client = AsyncMock()
+
+    with pytest.raises(expected_exception, match=message):
+        await coordinator._async_fetch_once()
+
+
+@pytest.mark.parametrize(
+    ("error", "message"),
+    [
+        (_response_error(500), "HTTP error with NanoKVM"),
+        (asyncio.TimeoutError(), "Timed out communicating with NanoKVM"),
+        (NanoKVMError("broken response"), "Error communicating with NanoKVM"),
+    ],
+)
+async def test_fetch_once_maps_non_authentication_failures(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    error: Exception,
+    message: str,
+) -> None:
+    """HTTP, timeout, and library errors retain stable update messages."""
+    coordinator._async_fetch_with_client = AsyncMock(side_effect=error)
+
+    with pytest.raises(UpdateFailed, match=message):
+        await coordinator._async_fetch_once()
+
+
+async def test_fetch_with_client_authenticates_and_runs_fetch_groups(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """An unauthenticated poll runs core, storage, optional, and snapshot stages."""
+    coordinator.client.token = None
+    coordinator._async_fetch_core_data = AsyncMock()
+    coordinator._async_fetch_storage_data = AsyncMock()
+    coordinator._async_refresh_ssh_data = AsyncMock()
+    coordinator._async_maybe_create_network_entities = MagicMock()
+    coordinator._async_maybe_create_media_entities = MagicMock()
+    coordinator._async_schedule_app_version_refresh = MagicMock()
+    coordinator._build_update_data = MagicMock(return_value={"ready": True})
+
+    assert await coordinator._async_fetch_with_client() == {"ready": True}
+    coordinator.client.authenticate.assert_awaited_once_with("admin", "password")
+    coordinator._async_fetch_core_data.assert_awaited_once_with()
+    coordinator._async_fetch_storage_data.assert_awaited_once_with()
+    coordinator._async_refresh_ssh_data.assert_awaited_once_with()
+    coordinator._async_maybe_create_network_entities.assert_called_once_with()
+    coordinator._async_maybe_create_media_entities.assert_called_once_with()
+    coordinator._async_schedule_app_version_refresh.assert_called_once_with()
+
+
+async def test_reauthentication_rejects_invalid_stored_credentials(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Candidate authentication failure starts the HA reauth flow."""
+    candidate = _candidate_client(
+        "http://nanokvm.local/api/",
+        authenticate_error=NanoKVMAuthenticationFailure("invalid"),
+    )
+    monkeypatch.setattr(
+        coordinator_module, "NanoKVMClient", MagicMock(return_value=candidate)
+    )
+
+    with pytest.raises(ConfigEntryAuthFailed, match="Stored NanoKVM credentials"):
+        await coordinator._async_reauthenticate_client_locked(_response_error(401))
+
+
+async def test_reauthentication_maps_non_auth_http_error(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-auth HTTP response from authentication is retryable."""
+    candidate = _candidate_client(
+        "http://nanokvm.local/api/",
+        authenticate_error=_response_error(500),
+    )
+    monkeypatch.setattr(
+        coordinator_module, "NanoKVMClient", MagicMock(return_value=candidate)
+    )
+
+    with pytest.raises(UpdateFailed, match="Reauthentication failed"):
+        await coordinator._async_reauthenticate_client_locked(_response_error(401))
+
+
+async def test_reauthentication_fingerprint_redirect_tries_https(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fingerprint mismatch reached through HTTP continues to HTTPS."""
+    mismatch = aiohttp.ServerFingerprintMismatch(b"expected", b"actual", "nano", 443)
+    http_candidate = _candidate_client(
+        "http://nanokvm.local/api/",
+        authenticate_error=mismatch,
+    )
+    https_candidate = _candidate_client("https://nanokvm.local/api/")
+    factory = MagicMock(side_effect=[http_candidate, https_candidate])
+    monkeypatch.setattr(coordinator_module, "NanoKVMClient", factory)
+
+    await coordinator._async_reauthenticate_client_locked(_response_error(401))
+
+    assert coordinator.client is https_candidate
+    assert factory.call_count == 2
+
+
+async def test_reauthentication_https_fingerprint_failure_is_auth_failed(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fingerprint mismatch on an explicit HTTPS target requires confirmation."""
+    config_entry_mock.data[CONF_HOST] = "https://nanokvm.local"
+    coordinator.client.url = URL("https://nanokvm.local/api/")
+    mismatch = aiohttp.ServerFingerprintMismatch(b"expected", b"actual", "nano", 443)
+    candidate = _candidate_client(
+        "https://nanokvm.local/api/",
+        authenticate_error=mismatch,
+    )
+    monkeypatch.setattr(
+        coordinator_module, "NanoKVMClient", MagicMock(return_value=candidate)
+    )
+
+    with pytest.raises(ConfigEntryAuthFailed, match="SSL certificate changed"):
+        await coordinator._async_reauthenticate_client_locked(_response_error(401))
+
+
+@pytest.mark.parametrize(
+    ("original_error", "candidate_error", "message"),
+    [
+        (_response_error(401), asyncio.TimeoutError(), "Timed out reauthenticating"),
+        (RuntimeError("token"), asyncio.TimeoutError(), "Timed out authenticating"),
+        (_response_error(401), NanoKVMError("broken"), "Reauthentication failed"),
+        (RuntimeError("token"), NanoKVMError("broken"), "Authentication failed"),
+    ],
+)
+async def test_reauthentication_maps_timeout_and_library_errors(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    original_error: Exception,
+    candidate_error: Exception,
+    message: str,
+) -> None:
+    """Reauthentication messages distinguish refresh from initial authentication."""
+    config_entry_mock.data[CONF_HOST] = "http://nanokvm.local"
+    candidate = _candidate_client(
+        "http://nanokvm.local/api/",
+        authenticate_error=candidate_error,
+    )
+    monkeypatch.setattr(
+        coordinator_module, "NanoKVMClient", MagicMock(return_value=candidate)
+    )
+
+    with pytest.raises(UpdateFailed, match=message):
+        await coordinator._async_reauthenticate_client_locked(original_error)
+
+
+@pytest.mark.parametrize(
+    ("original_error", "message"),
+    [
+        (_response_error(401), "Reauthentication failed"),
+        (RuntimeError("token"), "Authentication failed"),
+    ],
+)
+async def test_reauthentication_exhausts_connection_candidates(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    monkeypatch: pytest.MonkeyPatch,
+    original_error: Exception,
+    message: str,
+) -> None:
+    """Connection failures across both transports retain the correct context."""
+    candidates = [
+        _candidate_client(
+            "http://nanokvm.local/api/",
+            authenticate_error=aiohttp.ServerDisconnectedError("http"),
+        ),
+        _candidate_client(
+            "https://nanokvm.local/api/",
+            authenticate_error=aiohttp.ServerDisconnectedError("https"),
+        ),
+    ]
+    monkeypatch.setattr(
+        coordinator_module,
+        "NanoKVMClient",
+        MagicMock(side_effect=candidates),
+    )
+
+    with pytest.raises(UpdateFailed, match=message):
+        await coordinator._async_reauthenticate_client_locked(original_error)
+
+
+async def test_failover_replaces_client_after_authentication(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A working alternate transport becomes the shared client."""
+    candidate = _candidate_client("https://nanokvm.local/api/")
+    monkeypatch.setattr(
+        coordinator_module, "NanoKVMClient", MagicMock(return_value=candidate)
+    )
+
+    assert (
+        await coordinator._async_failover_client_locked(RuntimeError("disconnect"))
+        is True
+    )
+    assert coordinator.client is candidate
+    candidate.authenticate.assert_awaited_once_with("admin", "password")
+
+
+async def test_failover_wrapper_delegates_to_serialized_implementation(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """Public failover access delegates while owning the client lock."""
+    original_error = RuntimeError("disconnect")
+    coordinator._async_failover_client_locked = AsyncMock(return_value=True)
+
+    assert await coordinator._async_failover_client(original_error) is True
+    coordinator._async_failover_client_locked.assert_awaited_once_with(original_error)
+
+
+@pytest.mark.parametrize(
+    ("candidate_error", "expected_exception", "message"),
+    [
+        (
+            NanoKVMAuthenticationFailure("invalid"),
+            ConfigEntryAuthFailed,
+            "Stored NanoKVM credentials",
+        ),
+        (
+            aiohttp.ServerFingerprintMismatch(b"expected", b"actual", "nano", 443),
+            ConfigEntryAuthFailed,
+            "SSL certificate changed",
+        ),
+        (
+            asyncio.TimeoutError(),
+            UpdateFailed,
+            "Timed out checking alternate NanoKVM API transport",
+        ),
+        (NanoKVMError("broken"), UpdateFailed, "Error communicating with NanoKVM"),
+    ],
+)
+async def test_failover_maps_candidate_errors(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    monkeypatch: pytest.MonkeyPatch,
+    candidate_error: Exception,
+    expected_exception: type[Exception],
+    message: str,
+) -> None:
+    """Alternate transport failures preserve auth, certificate, and retry contracts."""
+    candidate = _candidate_client(
+        "https://nanokvm.local/api/",
+        authenticate_error=candidate_error,
+    )
+    monkeypatch.setattr(
+        coordinator_module, "NanoKVMClient", MagicMock(return_value=candidate)
+    )
+
+    with pytest.raises(expected_exception, match=message):
+        await coordinator._async_failover_client_locked(RuntimeError("disconnect"))
+
+
+async def test_failover_returns_false_when_connector_cannot_reach_alternate(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreachable alternate transport leaves the current client unchanged."""
+    current = coordinator.client
+    candidate = _candidate_client(
+        "https://nanokvm.local/api/",
+        authenticate_error=aiohttp.ClientConnectorError(None, OSError("refused")),
+    )
+    monkeypatch.setattr(
+        coordinator_module, "NanoKVMClient", MagicMock(return_value=candidate)
+    )
+
+    assert (
+        await coordinator._async_failover_client_locked(RuntimeError("disconnect"))
+        is False
+    )
+    assert coordinator.client is current
+
+
+async def test_failover_explicit_scheme_has_no_alternate(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    config_entry_mock: MagicMock,
+) -> None:
+    """An explicitly configured transport has no implicit alternate."""
+    config_entry_mock.data[CONF_HOST] = "http://nanokvm.local"
+
+    assert (
+        await coordinator._async_failover_client_locked(RuntimeError("disconnect"))
+        is False
+    )
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (NanoKVMNotSupportedError("unsupported"), None),
+        (_api_error(), None),
+        (_response_error(404), None),
+    ],
+)
+async def test_optional_endpoint_suppresses_unavailable_responses(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    error: Exception,
+    expected: None,
+) -> None:
+    """Known optional-endpoint failures produce unavailable state."""
+    endpoint = AsyncMock(side_effect=error)
+
+    assert await coordinator._fetch_optional("/optional", endpoint) is expected
+
+
+async def test_optional_endpoint_returns_value_and_reraises_other_http_errors(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """Optional calls return success and do not hide non-404 HTTP failures."""
+    endpoint = AsyncMock(return_value={"enabled": True})
+    assert await coordinator._fetch_optional("/optional", endpoint) == {"enabled": True}
+
+    endpoint.side_effect = _response_error(500)
+    with pytest.raises(aiohttp.ClientResponseError):
+        await coordinator._fetch_optional("/optional", endpoint)
+
+
+async def test_oled_fetch_handles_only_missing_optional_file(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """The OLED helper suppresses only the known missing-file response."""
+    oled = GetOLEDRsp(exist=True, sleep=60)
+    coordinator.client.get_oled_info.return_value = oled
+    assert await coordinator._fetch_oled_info() is oled
+
+    coordinator.client.get_oled_info.side_effect = _api_error(
+        code=-2,
+        message="invalid file content",
+    )
+    assert await coordinator._fetch_oled_info() is None
+
+    coordinator.client.get_oled_info.side_effect = _api_error()
+    with pytest.raises(NanoKVMApiError):
+        await coordinator._fetch_oled_info()
+
+
+async def test_core_fetch_populates_pcie_state(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """PCIe polling assigns required and non-Pro optional endpoint state."""
+    responses = _configure_required_client_responses(
+        coordinator.client,
+        hardware=HWVersion.PCIE,
+    )
+
+    await coordinator._async_fetch_core_data()
+
+    for attribute in (
+        "device_info",
+        "hostname_info",
+        "hardware_info",
+        "gpio_info",
+        "virtual_device_info",
+        "ssh_state",
+        "mdns_state",
+        "hid_mode",
+        "oled_info",
+        "wifi_status",
+        "hdmi_state",
+        "mouse_jiggler_state",
+        "swap_size",
+        "tailscale_status",
+    ):
+        assert getattr(coordinator, attribute) == responses[attribute]
+    assert coordinator.hdmi_capture is None
+    assert coordinator.static_ip is None
+
+
+async def test_core_fetch_skips_hardware_gated_endpoints_without_hardware(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """Missing hardware identity clears all hardware-gated state."""
+    _configure_required_client_responses(coordinator.client, hardware=None)
+    coordinator.virtual_device_info = object()
+    coordinator.hdmi_state = object()
+    coordinator.swap_size = 256
+
+    await coordinator._async_fetch_core_data()
+
+    assert coordinator.virtual_device_info is None
+    assert coordinator.hdmi_state is None
+    assert coordinator.swap_size is None
+    coordinator.client.get_virtual_device_status.assert_not_awaited()
+    coordinator.client.get_hdmi_state.assert_not_awaited()
+    coordinator.client.get_swap_size.assert_not_awaited()
+
+
+async def test_core_fetch_populates_pro_optional_state(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """Pro polling stores every supported Pro response."""
+    _configure_required_client_responses(coordinator.client, hardware=HWVersion.PRO)
+    expected = {
+        "hdmi_capture": GetHdmiCaptureRsp(enabled=True),
+        "hdmi_passthrough": GetHdmiPassthroughRsp(enabled=False),
+        "low_power": GetLowPowerRsp(enabled=True),
+        "led_strip": GetLedStripRsp(on=True, hor=20, ver=30, brightness=80),
+        "lcd_time_format": GetLcdTimeFormatRsp(format=LcdTimeFormat.TWENTY_FOUR_HOUR),
+        "time_status": GetTimeStatusRsp(isSynchronized=True, lastSyncTime=1234),
+        "static_ip": GetStaticIPRsp(enabled=True, ip="192.0.2.50"),
+    }
+    coordinator.client.get_hdmi_capture.return_value = expected["hdmi_capture"]
+    coordinator.client.get_hdmi_passthrough.return_value = expected["hdmi_passthrough"]
+    coordinator.client.get_low_power.return_value = expected["low_power"]
+    coordinator.client.get_led_strip.return_value = expected["led_strip"]
+    coordinator.client.get_lcd_time_format.return_value = expected["lcd_time_format"]
+    coordinator.client.get_time_status.return_value = expected["time_status"]
+    coordinator.client.get_static_ip.return_value = expected["static_ip"]
+
+    await coordinator._async_fetch_core_data()
+
+    for attribute, value in expected.items():
+        assert getattr(coordinator, attribute) == value
+    assert coordinator.hdmi_state is None
+    assert coordinator.swap_size is None
+
+
+async def test_storage_fetch_reads_mounted_image_and_cdrom(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """Normal HID mode reads mounted-image and supported CD-ROM state."""
+    coordinator.hid_mode = GetHidModeRsp(mode=HidMode.NORMAL)
+    coordinator.hardware_info = GetHardwareRsp(version=HWVersion.PCIE)
+    mounted = GetMountedImageRsp(file="images/rescue.iso", cdrom=True, readOnly=True)
+    cdrom = GetCdRomRsp(cdrom=1)
+    coordinator.client.get_mounted_image.return_value = mounted
+    coordinator.client.get_cdrom_status.return_value = cdrom
+
+    await coordinator._async_fetch_storage_data()
+
+    assert coordinator.mounted_image == mounted
+    assert coordinator.cdrom_status == cdrom
+
+
+async def test_storage_fetch_uses_default_when_mounted_image_fails(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """A mounted-image API error produces the documented empty state."""
+    coordinator.hid_mode = GetHidModeRsp(mode=HidMode.NORMAL)
+    coordinator.hardware_info = GetHardwareRsp(version=HWVersion.PCIE)
+    coordinator.client.get_mounted_image.side_effect = _api_error()
+    coordinator.client.get_cdrom_status.side_effect = NanoKVMNotSupportedError()
+
+    await coordinator._async_fetch_storage_data()
+
+    assert coordinator.mounted_image == GetMountedImageRsp(
+        file="",
+        cdrom=False,
+        readOnly=False,
+    )
+    assert coordinator.cdrom_status is None
+
+
+async def test_storage_fetch_skips_cdrom_for_pro_in_normal_hid_mode(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """Normal HID on Pro reads media but skips the non-Pro CD-ROM endpoint."""
+    coordinator.hid_mode = GetHidModeRsp(mode=HidMode.NORMAL)
+    coordinator.hardware_info = GetHardwareRsp(version=HWVersion.PRO)
+    mounted = GetMountedImageRsp(file="images/rescue.iso")
+    coordinator.client.get_mounted_image.return_value = mounted
+
+    await coordinator._async_fetch_storage_data()
+
+    assert coordinator.mounted_image == mounted
+    assert coordinator.cdrom_status is None
+    coordinator.client.get_cdrom_status.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("hardware", "expected_cdrom"),
+    [
+        (HWVersion.PCIE, GetCdRomRsp(cdrom=0)),
+        (HWVersion.PRO, None),
+    ],
+)
+async def test_storage_fetch_uses_defaults_outside_normal_hid_mode(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    hardware: HWVersion,
+    expected_cdrom: GetCdRomRsp | None,
+) -> None:
+    """Storage endpoints are skipped when HID mode cannot expose media."""
+    coordinator.hid_mode = GetHidModeRsp(mode=HidMode.HID_ONLY)
+    coordinator.hardware_info = GetHardwareRsp(version=hardware)
+
+    await coordinator._async_fetch_storage_data()
+
+    assert coordinator.mounted_image == GetMountedImageRsp(
+        file="",
+        cdrom=False,
+        readOnly=False,
+    )
+    assert coordinator.cdrom_status == expected_cdrom
+    coordinator.client.get_mounted_image.assert_not_awaited()
+
+
+def test_build_update_data_returns_complete_state_snapshot(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """The coordinator snapshot includes every entity-facing API field."""
+    keys = (
+        "device_info",
+        "hardware_info",
+        "gpio_info",
+        "virtual_device_info",
+        "ssh_state",
+        "mdns_state",
+        "hid_mode",
+        "oled_info",
+        "wifi_status",
+        "application_version_info",
+        "mounted_image",
+        "cdrom_status",
+        "mouse_jiggler_state",
+        "hdmi_state",
+        "hdmi_capture",
+        "hdmi_passthrough",
+        "low_power",
+        "led_strip",
+        "lcd_time_format",
+        "time_status",
+        "static_ip",
+        "swap_size",
+        "tailscale_status",
+        "hostname_info",
+        "watchdog_enabled",
+    )
+    expected = {key: object() for key in keys}
+    for key, value in expected.items():
+        setattr(coordinator, key, value)
+
+    assert coordinator._build_update_data() == expected
+
+
+@pytest.mark.parametrize(
+    ("application", "expected"),
+    [
+        ("", False),
+        (" ", False),
+        ("2.2.1", False),
+        ("2.2.2", True),
+        ("2.3.0", True),
+        ("not a version", False),
+    ],
+)
+def test_watchdog_capability_uses_application_version(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    application: str,
+    expected: bool,
+) -> None:
+    """Watchdog support begins at firmware 2.2.2 and rejects invalid versions."""
+    coordinator.device_info = _device_info(application=application)
+
+    assert coordinator.supports_watchdog is expected
+
+
+@pytest.mark.parametrize(
+    (
+        "hardware",
+        "is_pro",
+        "non_pro_virtual",
+        "hdmi",
+        "swap",
+        "cdrom",
+    ),
+    [
+        (None, False, False, False, False, False),
+        (HWVersion.ALPHA, False, True, False, True, True),
+        (HWVersion.PCIE, False, True, True, True, True),
+        (HWVersion.PRO, True, False, False, False, False),
+    ],
+)
+def test_hardware_capability_properties(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    hardware: HWVersion | None,
+    is_pro: bool,
+    non_pro_virtual: bool,
+    hdmi: bool,
+    swap: bool,
+    cdrom: bool,
+) -> None:
+    """Hardware gates match the endpoints exposed for each product family."""
+    coordinator.hardware_info = (
+        None if hardware is None else GetHardwareRsp(version=hardware)
+    )
+    coordinator.virtual_device_info = (
+        GetVirtualDeviceRsp(network=True)
+        if hardware in (HWVersion.ALPHA, HWVersion.PCIE)
+        else None
+    )
+
+    assert coordinator.is_pro_hardware is is_pro
+    assert coordinator.supports_non_pro_virtual_device_controls is non_pro_virtual
+    assert coordinator.supports_hdmi_endpoint is hdmi
+    assert coordinator.supports_swap_size is swap
+    assert coordinator.supports_cdrom_endpoint is cdrom
+
+
+def test_active_network_connection_types_are_normalized_and_deduplicated(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """Only addressed connection types contribute dynamic entities."""
+    coordinator.device_info = _device_info(
+        ips=[
+            IPInfo(name="eth0", addr="192.0.2.10", version="IPv4", type="WiReD"),
+            IPInfo(name="eth1", addr="192.0.2.11", version="IPv4", type="wired"),
+            IPInfo(name="wlan0", addr="", version="IPv4", type="wireless"),
+        ]
+    )
+
+    assert coordinator._active_network_connection_types() == {"wired"}
+
+
+async def test_ensure_ssh_collector_creates_once_and_reuses(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SSH collector creation uses the API host and configured password once."""
+    collector = object()
+    factory = MagicMock(return_value=collector)
+    monkeypatch.setattr(coordinator_module, "SSHMetricsCollector", factory)
+
+    assert await coordinator.async_ensure_ssh_metrics_collector() is collector
+    assert await coordinator.async_ensure_ssh_metrics_collector() is collector
+    factory.assert_called_once_with(host="nanokvm.local", password="password")
+
+
+def test_media_entity_signal_is_sent_once_after_mount(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The first mounted image emits one entry-scoped media signal."""
+    dispatcher = MagicMock()
+    monkeypatch.setattr(coordinator_module, "async_dispatcher_send", dispatcher)
+
+    coordinator.mounted_image = None
+    coordinator._async_maybe_create_media_entities()
+    coordinator.mounted_image = GetMountedImageRsp(file="images/rescue.iso")
+    coordinator._async_maybe_create_media_entities()
+    coordinator._async_maybe_create_media_entities()
+
+    dispatcher.assert_called_once_with(
+        coordinator.hass,
+        SIGNAL_NEW_MEDIA_ENTITIES.format(coordinator.config_entry.entry_id),
+    )
+    assert coordinator.media_entities_created is True
+
+
+def test_network_entity_signals_are_sent_once_per_connection_type(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dynamic network signals are normalized and idempotent by type."""
+    dispatcher = MagicMock()
+    monkeypatch.setattr(coordinator_module, "async_dispatcher_send", dispatcher)
+    coordinator.device_info = _device_info(
+        ips=[
+            IPInfo(name="eth0", addr="192.0.2.10", version="IPv4", type="wired"),
+            IPInfo(
+                name="wlan0",
+                addr="192.0.2.20",
+                version="IPv4",
+                type="WIRELESS",
+            ),
+        ]
+    )
+
+    coordinator._async_maybe_create_network_entities()
+    coordinator._async_maybe_create_network_entities()
+
+    assert dispatcher.call_count == 2
+    signal = SIGNAL_NEW_NETWORK_ENTITIES.format(coordinator.config_entry.entry_id)
+    assert {(args.args[1], args.args[2]) for args in dispatcher.call_args_list} == {
+        (signal, "wired"),
+        (signal, "wireless"),
+    }
+    assert coordinator.network_entities_created == {"wired", "wireless"}
+
+
+async def test_successful_ssh_update_assigns_metrics_and_signals_once(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Successful SSH collection stores metrics and creates supported entities."""
+    metrics = SSHMetricsSnapshot(
+        uptime=datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC),
+        cpu_temperature=51.5,
+        memory_total=512.0,
+        memory_used_percent=25.0,
+        storage_total=1024.0,
+        storage_used_percent=50.0,
+        watchdog_enabled=False,
+    )
+    collector = SimpleNamespace(
+        collect=AsyncMock(return_value=metrics),
+        disconnect=AsyncMock(),
+    )
+    coordinator.ssh_metrics_collector = collector
+    coordinator.device_info = _device_info(application="2.2.2")
+    dispatcher = MagicMock()
+    monkeypatch.setattr(coordinator_module, "async_dispatcher_send", dispatcher)
+
+    await coordinator._async_update_ssh_data()
+    await coordinator._async_update_ssh_data()
+
+    assert coordinator.uptime == metrics.uptime
+    assert coordinator.cpu_temperature == metrics.cpu_temperature
+    assert coordinator.memory_total == metrics.memory_total
+    assert coordinator.memory_used_percent == metrics.memory_used_percent
+    assert coordinator.storage_total == metrics.storage_total
+    assert coordinator.storage_used_percent == metrics.storage_used_percent
+    assert coordinator.watchdog_enabled is False
+    assert dispatcher.call_args_list == [
+        call(
+            coordinator.hass,
+            SIGNAL_NEW_SSH_SENSORS.format(coordinator.config_entry.entry_id),
+        ),
+        call(
+            coordinator.hass,
+            SIGNAL_NEW_SSH_SWITCHES.format(coordinator.config_entry.entry_id),
+        ),
+    ]
+    assert collector.collect.await_count == 2
+
+
+async def test_failed_ssh_update_clears_metrics_and_disconnects(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """An SSH collection failure clears stale metrics without failing the poll."""
+    collector = SimpleNamespace(
+        collect=AsyncMock(side_effect=RuntimeError("ssh failed")),
+        disconnect=AsyncMock(),
+    )
+    coordinator.ssh_metrics_collector = collector
+    coordinator.uptime = datetime.datetime.now(datetime.UTC)
+    coordinator.watchdog_enabled = True
+
+    await coordinator._async_update_ssh_data()
+
+    assert coordinator.uptime is None
+    assert coordinator.watchdog_enabled is None
+    collector.disconnect.assert_awaited_once_with()
+
+
+async def test_disabled_ssh_refresh_clears_collector_and_metrics(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """Disabling SSH disconnects and removes its collector."""
+    collector = SimpleNamespace(disconnect=AsyncMock())
+    coordinator.ssh_metrics_collector = collector
+    coordinator.ssh_state = GetSSHStateRsp(enabled=False)
+    coordinator.cpu_temperature = 50.0
+
+    await coordinator._async_refresh_ssh_data()
+
+    assert coordinator.cpu_temperature is None
+    assert coordinator.ssh_metrics_collector is None
+    collector.disconnect.assert_awaited_once_with()
+
+
+async def test_app_version_schedule_refreshes_state_and_listeners(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """A stale version cache schedules one background refresh."""
+    version = GetVersionRsp(current="2.2.2", latest="2.3.0")
+    coordinator._async_fetch_app_version = AsyncMock(return_value=version)
+    coordinator.async_update_listeners = MagicMock()
+    coordinator.hass.async_create_task = asyncio.create_task
+
+    coordinator._async_schedule_app_version_refresh()
+    task = coordinator._app_version_fetch_task
+    assert task is not None
+    await task
+
+    assert coordinator.application_version_info == version
+    assert coordinator._app_version_last_fetched is not None
+    assert coordinator._app_version_fetch_task is None
+    coordinator.async_update_listeners.assert_called_once_with()
+
+
+async def test_app_version_schedule_skips_active_and_fresh_cache(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """An active task or fresh success/failure cache suppresses duplicate work."""
+    active_task = asyncio.create_task(asyncio.Event().wait())
+    coordinator._app_version_fetch_task = active_task
+    coordinator.hass.async_create_task = MagicMock()
+    coordinator._async_schedule_app_version_refresh()
+    coordinator.hass.async_create_task.assert_not_called()
+    active_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await active_task
+
+    coordinator._app_version_fetch_task = None
+    coordinator._app_version_last_fetched = datetime.datetime.now(datetime.UTC)
+    coordinator.application_version_info = GetVersionRsp(
+        current="2.2.2", latest="2.3.0"
+    )
+    coordinator._async_schedule_app_version_refresh()
+    coordinator.hass.async_create_task.assert_not_called()
+
+    coordinator.application_version_info = None
+    coordinator._async_schedule_app_version_refresh()
+    coordinator.hass.async_create_task.assert_not_called()
+
+
+async def test_app_version_refresh_cancellation_clears_task_reference(
+    coordinator: NanoKVMDataUpdateCoordinator,
+) -> None:
+    """Cancelling a version refresh leaves no stale task reference."""
+    started = asyncio.Event()
+
+    async def wait_for_cancellation() -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    coordinator._async_fetch_app_version = wait_for_cancellation
+    task = asyncio.create_task(coordinator._async_refresh_app_version())
+    coordinator._app_version_fetch_task = task
+    await started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert coordinator._app_version_fetch_task is None
+
+
+async def test_app_version_client_returns_value_and_suppresses_device_failure(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The dedicated version client copies transport auth and isolates failures."""
+    fingerprint = "AA" * 32
+    config_entry_mock.data[CONF_SSL_FINGERPRINT] = fingerprint
+    version = GetVersionRsp(current="2.2.2", latest="2.3.0")
+    success = _candidate_client("http://nanokvm.local/api/")
+    success.get_application_version.return_value = version
+    failure = _candidate_client("http://nanokvm.local/api/")
+    failure.get_application_version.side_effect = NanoKVMError("offline")
+    factory = MagicMock(side_effect=[success, failure])
+    monkeypatch.setattr(coordinator_module, "NanoKVMClient", factory)
+
+    assert await coordinator._async_fetch_app_version() == version
+    assert await coordinator._async_fetch_app_version() is None
+    assert factory.call_args_list == [
+        call(
+            "http://nanokvm.local/api/",
+            token="token",
+            ssl_fingerprint=fingerprint,
+            request_timeout=45,
+        ),
+        call(
+            "http://nanokvm.local/api/",
+            token="token",
+            ssl_fingerprint=fingerprint,
+            request_timeout=45,
+        ),
+    ]
+
+
+async def test_shutdown_cleans_owned_resources_when_base_shutdown_fails(
+    coordinator: NanoKVMDataUpdateCoordinator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Coordinator-owned tasks and SSH are released even if base cleanup fails."""
+    task = asyncio.create_task(asyncio.Event().wait())
+    collector = SimpleNamespace(disconnect=AsyncMock())
+    coordinator._app_version_fetch_task = task
+    coordinator.ssh_metrics_collector = collector
+    base_shutdown = AsyncMock(side_effect=RuntimeError("base failed"))
+    monkeypatch.setattr(DataUpdateCoordinator, "async_shutdown", base_shutdown)
+
+    with pytest.raises(RuntimeError, match="base failed"):
+        await coordinator.async_shutdown()
+
+    assert task.cancelled()
+    assert coordinator._app_version_fetch_task is None
+    collector.disconnect.assert_awaited_once_with()
+    assert coordinator.ssh_metrics_collector is None

--- a/tests/core/test_integration_lifecycle.py
+++ b/tests/core/test_integration_lifecycle.py
@@ -1,0 +1,430 @@
+"""Tests for NanoKVM config-entry setup and unload lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from nanokvm.client import NanoKVMAuthenticationFailure, NanoKVMError
+import pytest
+from yarl import URL
+
+import custom_components.nanokvm as nanokvm_module
+from custom_components.nanokvm import PLATFORMS, async_setup_entry, async_unload_entry
+from custom_components.nanokvm.const import (
+    CONF_SSL_FINGERPRINT,
+    CONF_USE_STATIC_HOST,
+    DOMAIN,
+)
+
+
+@dataclass(slots=True)
+class SetupScenario:
+    """Script one setup client's authentication and device-info behavior."""
+
+    auth_error: Exception | None = None
+    info_error: Exception | None = None
+    device_info: object | None = None
+
+
+class SetupClient:
+    """Minimal async NanoKVM client used at the integration boundary."""
+
+    scenarios: list[SetupScenario] = []
+    instances: list[SetupClient] = []
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        ssl_fingerprint: str | None = None,
+        **_: object,
+    ) -> None:
+        if not self.scenarios:
+            raise AssertionError(f"No setup scenario configured for {url}")
+        self.scenario = self.scenarios.pop(0)
+        self.url = URL(url)
+        self.ssl_fingerprint = ssl_fingerprint
+        self.authenticate_calls: list[tuple[str, str]] = []
+        self.entered = False
+        self.exited = False
+        self.instances.append(self)
+
+    async def __aenter__(self) -> SetupClient:
+        """Enter the fake setup client context."""
+        self.entered = True
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        """Exit the fake setup client context."""
+        self.exited = True
+
+    async def authenticate(self, username: str, password: str) -> None:
+        """Record credentials and raise any scripted authentication error."""
+        self.authenticate_calls.append((username, password))
+        if self.scenario.auth_error is not None:
+            raise self.scenario.auth_error
+
+    async def get_info(self) -> object:
+        """Return complete initial device info or raise its scripted error."""
+        if self.scenario.info_error is not None:
+            raise self.scenario.info_error
+        if self.scenario.device_info is not None:
+            return self.scenario.device_info
+        return SimpleNamespace(device_key="device-key", application="1.0.0")
+
+
+@pytest.fixture
+def install_setup_client(monkeypatch: pytest.MonkeyPatch):
+    """Install a clean setup client and return its scenario setter."""
+
+    def install(*scenarios: SetupScenario) -> type[SetupClient]:
+        SetupClient.scenarios = list(scenarios)
+        SetupClient.instances = []
+        monkeypatch.setattr(nanokvm_module, "NanoKVMClient", SetupClient)
+        return SetupClient
+
+    return install
+
+
+def _install_coordinator(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    refresh_error: Exception | None = None,
+) -> tuple[MagicMock, SimpleNamespace]:
+    """Install a coordinator factory with a scripted first refresh."""
+    refresh = AsyncMock(side_effect=refresh_error)
+    coordinator = SimpleNamespace(async_config_entry_first_refresh=refresh)
+    factory = MagicMock(return_value=coordinator)
+    monkeypatch.setattr(nanokvm_module, "NanoKVMDataUpdateCoordinator", factory)
+    return factory, coordinator
+
+
+def _prepare_hass(hass_mock: MagicMock) -> None:
+    """Complete the Home Assistant config-entry async boundary."""
+    hass_mock.config_entries.async_forward_entry_setups = AsyncMock()
+    hass_mock.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_success_initializes_coordinator_platforms_and_services(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    install_setup_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful entry is refreshed, stored, forwarded, and service-enabled."""
+    _prepare_hass(hass_mock)
+    config_entry_mock.data[CONF_USE_STATIC_HOST] = True
+    client_type = install_setup_client(SetupScenario())
+    coordinator_factory, coordinator = _install_coordinator(monkeypatch)
+    register_services = MagicMock()
+    monkeypatch.setattr(nanokvm_module, "async_register_services", register_services)
+
+    assert await async_setup_entry(hass_mock, config_entry_mock) is True
+
+    client = client_type.instances[0]
+    assert client.url == URL("http://nanokvm.local/api/")
+    assert client.ssl_fingerprint is None
+    assert client.authenticate_calls == [("admin", "password")]
+    assert client.entered is True
+    assert client.exited is True
+    coordinator_factory.assert_called_once()
+    assert coordinator_factory.call_args.args == (hass_mock, config_entry_mock)
+    assert coordinator_factory.call_args.kwargs == {
+        "client": client,
+        "username": "admin",
+        "password": "password",
+        "device_info": client.scenario.device_info
+        or SimpleNamespace(device_key="device-key", application="1.0.0"),
+    }
+    coordinator.async_config_entry_first_refresh.assert_awaited_once_with()
+    assert hass_mock.data[DOMAIN][config_entry_mock.entry_id] is coordinator
+    hass_mock.config_entries.async_forward_entry_setups.assert_awaited_once_with(
+        config_entry_mock,
+        PLATFORMS,
+    )
+    register_services.assert_called_once_with(hass_mock)
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_explicit_https_passes_stored_fingerprint(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    install_setup_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit HTTPS entry uses its persisted certificate pin."""
+    _prepare_hass(hass_mock)
+    config_entry_mock.data["host"] = "https://nanokvm.local"
+    config_entry_mock.data[CONF_SSL_FINGERPRINT] = "AABB"
+    client_type = install_setup_client(SetupScenario())
+    _install_coordinator(monkeypatch)
+    monkeypatch.setattr(nanokvm_module, "async_register_services", MagicMock())
+
+    assert await async_setup_entry(hass_mock, config_entry_mock) is True
+    assert len(client_type.instances) == 1
+    assert client_type.instances[0].url.scheme == "https"
+    assert client_type.instances[0].ssl_fingerprint == "AABB"
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_authentication_failure_requests_reauth(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    install_setup_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid stored credentials map to Home Assistant's reauth exception."""
+    _prepare_hass(hass_mock)
+    client_type = install_setup_client(
+        SetupScenario(auth_error=NanoKVMAuthenticationFailure("invalid")),
+        SetupScenario(),
+    )
+    coordinator_factory, _ = _install_coordinator(monkeypatch)
+
+    with pytest.raises(ConfigEntryAuthFailed, match="Authentication failed"):
+        await async_setup_entry(hass_mock, config_entry_mock)
+
+    assert len(client_type.instances) == 1
+    coordinator_factory.assert_not_called()
+    assert DOMAIN not in hass_mock.data
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_http_certificate_error_falls_back_to_https(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    install_setup_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A redirect certificate failure on HTTP retries the direct HTTPS candidate."""
+    _prepare_hass(hass_mock)
+    mismatch = aiohttp.ServerFingerprintMismatch(
+        b"expected", b"received", "nanokvm.local", 443
+    )
+    client_type = install_setup_client(
+        SetupScenario(auth_error=mismatch),
+        SetupScenario(),
+    )
+    coordinator_factory, _ = _install_coordinator(monkeypatch)
+    monkeypatch.setattr(nanokvm_module, "async_register_services", MagicMock())
+
+    assert await async_setup_entry(hass_mock, config_entry_mock) is True
+    assert [client.url.scheme for client in client_type.instances] == ["http", "https"]
+    assert coordinator_factory.call_args.kwargs["client"] is client_type.instances[1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "certificate_error",
+    [
+        aiohttp.ServerFingerprintMismatch(
+            b"expected", b"received", "nanokvm.local", 443
+        ),
+        aiohttp.ClientConnectorCertificateError(None, ValueError("certificate")),
+    ],
+)
+async def test_setup_entry_final_certificate_error_requests_reauth(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    install_setup_client,
+    monkeypatch: pytest.MonkeyPatch,
+    certificate_error: Exception,
+) -> None:
+    """A certificate failure on the final transport maps to auth recovery."""
+    _prepare_hass(hass_mock)
+    config_entry_mock.data["host"] = "https://nanokvm.local"
+    install_setup_client(SetupScenario(auth_error=certificate_error))
+    coordinator_factory, _ = _install_coordinator(monkeypatch)
+
+    with pytest.raises(ConfigEntryAuthFailed, match="SSL certificate changed"):
+        await async_setup_entry(hass_mock, config_entry_mock)
+
+    coordinator_factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_exhausted_connection_candidates_is_not_ready(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    install_setup_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both unavailable transports defer entry setup with the final error."""
+    _prepare_hass(hass_mock)
+    first = aiohttp.ClientConnectionError("http unavailable")
+    last = aiohttp.ClientConnectionError("https unavailable")
+    client_type = install_setup_client(
+        SetupScenario(auth_error=first),
+        SetupScenario(auth_error=last),
+    )
+    coordinator_factory, _ = _install_coordinator(monkeypatch)
+
+    with pytest.raises(ConfigEntryNotReady) as error:
+        await async_setup_entry(hass_mock, config_entry_mock)
+
+    assert error.value.__cause__ is last
+    assert [client.url.scheme for client in client_type.instances] == ["http", "https"]
+    coordinator_factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        asyncio.TimeoutError(),
+        aiohttp.ClientPayloadError("invalid response"),
+        NanoKVMError("api failure"),
+    ],
+)
+async def test_setup_entry_non_connection_errors_stop_fallback(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    install_setup_client,
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+) -> None:
+    """Timeout, response, and API errors defer setup without probing HTTPS."""
+    _prepare_hass(hass_mock)
+    client_type = install_setup_client(
+        SetupScenario(info_error=error),
+        SetupScenario(),
+    )
+    coordinator_factory, _ = _install_coordinator(monkeypatch)
+
+    with pytest.raises(ConfigEntryNotReady) as setup_error:
+        await async_setup_entry(hass_mock, config_entry_mock)
+
+    assert setup_error.value.__cause__ is error
+    assert len(client_type.instances) == 1
+    coordinator_factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_first_refresh_failure_stops_platform_forwarding(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    install_setup_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Coordinator readiness must be established before storage and forwarding."""
+    _prepare_hass(hass_mock)
+    install_setup_client(SetupScenario())
+    refresh_error = ConfigEntryNotReady("poll failed")
+    _install_coordinator(monkeypatch, refresh_error=refresh_error)
+    register_services = MagicMock()
+    monkeypatch.setattr(nanokvm_module, "async_register_services", register_services)
+
+    with pytest.raises(ConfigEntryNotReady, match="poll failed"):
+        await async_setup_entry(hass_mock, config_entry_mock)
+
+    assert DOMAIN not in hass_mock.data
+    hass_mock.config_entries.async_forward_entry_setups.assert_not_awaited()
+    register_services.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_preserves_existing_domain_coordinators(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    install_setup_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Adding a second entry does not replace already configured coordinators."""
+    _prepare_hass(hass_mock)
+    existing = object()
+    hass_mock.data = {DOMAIN: {"existing-entry": existing}}
+    install_setup_client(SetupScenario())
+    _, coordinator = _install_coordinator(monkeypatch)
+    monkeypatch.setattr(nanokvm_module, "async_register_services", MagicMock())
+
+    assert await async_setup_entry(hass_mock, config_entry_mock) is True
+    assert hass_mock.data[DOMAIN] == {
+        "existing-entry": existing,
+        config_entry_mock.entry_id: coordinator,
+    }
+
+
+@pytest.mark.asyncio
+async def test_unload_failure_keeps_entry_and_services(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed platform unload leaves integration ownership untouched."""
+    _prepare_hass(hass_mock)
+    coordinator = object()
+    hass_mock.data = {DOMAIN: {config_entry_mock.entry_id: coordinator}}
+    hass_mock.config_entries.async_unload_platforms.return_value = False
+    unregister = MagicMock()
+    monkeypatch.setattr(nanokvm_module, "async_unregister_services", unregister)
+
+    assert await async_unload_entry(hass_mock, config_entry_mock) is False
+    assert hass_mock.data[DOMAIN][config_entry_mock.entry_id] is coordinator
+    unregister.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unload_one_of_multiple_entries_keeps_global_services(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Global services remain registered while another NanoKVM entry exists."""
+    _prepare_hass(hass_mock)
+    remaining = object()
+    hass_mock.data = {
+        DOMAIN: {
+            config_entry_mock.entry_id: object(),
+            "remaining-entry": remaining,
+        }
+    }
+    unregister = MagicMock()
+    monkeypatch.setattr(nanokvm_module, "async_unregister_services", unregister)
+
+    assert await async_unload_entry(hass_mock, config_entry_mock) is True
+    hass_mock.config_entries.async_unload_platforms.assert_awaited_once_with(
+        config_entry_mock,
+        PLATFORMS,
+    )
+    assert hass_mock.data[DOMAIN] == {"remaining-entry": remaining}
+    unregister.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unload_last_entry_unregisters_services_and_domain(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The final unload removes global services and the integration data bucket."""
+    _prepare_hass(hass_mock)
+    hass_mock.data = {DOMAIN: {config_entry_mock.entry_id: object()}}
+    unregister = MagicMock()
+    monkeypatch.setattr(nanokvm_module, "async_unregister_services", unregister)
+
+    assert await async_unload_entry(hass_mock, config_entry_mock) is True
+    assert DOMAIN not in hass_mock.data
+    unregister.assert_called_once_with(hass_mock)
+
+
+@pytest.mark.asyncio
+async def test_unload_missing_domain_is_idempotent(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A repeated unload safely applies the empty-domain cleanup path."""
+    _prepare_hass(hass_mock)
+    hass_mock.data = {}
+    unregister = MagicMock()
+    monkeypatch.setattr(nanokvm_module, "async_unregister_services", unregister)
+
+    assert await async_unload_entry(hass_mock, config_entry_mock) is True
+    unregister.assert_called_once_with(hass_mock)
+    assert DOMAIN not in hass_mock.data

--- a/tests/core/test_services.py
+++ b/tests/core/test_services.py
@@ -1,0 +1,819 @@
+"""Behavior tests for NanoKVM service registration and handlers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, call
+
+from homeassistant.core import ServiceCall, SupportsResponse
+from homeassistant.exceptions import HomeAssistantError
+from nanokvm.models import (
+    DownloadStatus,
+    GetCustomEdidListRsp,
+    GetImagesRsp,
+    GetLedStripRsp,
+    ImageEnabledRsp,
+    ScanWifiRsp,
+    StatusImageRsp,
+    WiFiInfo,
+)
+import pytest
+import voluptuous as vol
+
+from custom_components.nanokvm import services as services_module
+from custom_components.nanokvm.const import (
+    ATTR_BRIGHTNESS,
+    ATTR_BUTTON_TYPE,
+    ATTR_DURATION,
+    ATTR_ENABLED,
+    ATTR_HORIZONTAL_COUNT,
+    ATTR_MAC,
+    ATTR_MODE,
+    ATTR_ON,
+    ATTR_TEXT,
+    ATTR_VERTICAL_COUNT,
+    BUTTON_TYPE_POWER,
+    BUTTON_TYPE_RESET,
+    CONF_HOST,
+    DOMAIN,
+    SERVICE_GET_IMAGE_DOWNLOAD_STATUS,
+    SERVICE_IMAGE_DOWNLOAD_ENABLED,
+    SERVICE_LIST_CUSTOM_EDIDS,
+    SERVICE_LIST_IMAGES,
+    SERVICE_PASTE_TEXT,
+    SERVICE_PUSH_BUTTON,
+    SERVICE_REBOOT,
+    SERVICE_RESET_HDMI,
+    SERVICE_RESET_HID,
+    SERVICE_SCAN_WIFI,
+    SERVICE_SET_LED_STRIP,
+    SERVICE_SET_MOUSE_JIGGLER,
+    SERVICE_WAKE_ON_LAN,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RegisteredService:
+    """Service metadata captured at the Home Assistant registry boundary."""
+
+    handler: Callable[[ServiceCall], Awaitable[Any]]
+    schema: vol.Schema
+    supports_response: SupportsResponse
+
+
+class ModelResponse:
+    """Minimal model-dump boundary used by response normalization tests."""
+
+    def __init__(self, response: dict[str, Any]) -> None:
+        self.response = response
+        self.mode: str | None = None
+
+    def model_dump(self, *, mode: str) -> dict[str, Any]:
+        """Record the requested serialization mode and return JSON-ready data."""
+        self.mode = mode
+        return self.response
+
+
+def _client() -> SimpleNamespace:
+    """Return the NanoKVM client methods exposed through service handlers."""
+    return SimpleNamespace(
+        push_button=AsyncMock(),
+        paste_text=AsyncMock(),
+        reboot_system=AsyncMock(),
+        reset_hdmi=AsyncMock(),
+        reset_hid=AsyncMock(),
+        send_wake_on_lan=AsyncMock(),
+        set_mouse_jiggler_state=AsyncMock(),
+        set_led_strip=AsyncMock(),
+        scan_wifi=AsyncMock(),
+        get_images=AsyncMock(),
+        is_image_download_enabled=AsyncMock(),
+        get_image_download_status=AsyncMock(),
+        get_custom_edid_list=AsyncMock(),
+    )
+
+
+def _coordinator(
+    host: str | None = "nanokvm.local",
+    *,
+    client: SimpleNamespace | None = None,
+    is_pro_hardware: bool = False,
+    led_strip: GetLedStripRsp | None = None,
+    context_error: Exception | None = None,
+) -> SimpleNamespace:
+    """Return a coordinator with a serialized client-access boundary."""
+    service_client = client or _client()
+    entry_data = {CONF_HOST: host} if host is not None else {}
+
+    @asynccontextmanager
+    async def async_client():
+        if context_error is not None:
+            raise context_error
+        yield service_client
+
+    return SimpleNamespace(
+        config_entry=SimpleNamespace(data=entry_data),
+        client=service_client,
+        async_client=async_client,
+        async_request_refresh=AsyncMock(),
+        is_pro_hardware=is_pro_hardware,
+        led_strip=led_strip,
+    )
+
+
+def _service_registry(hass: MagicMock) -> SimpleNamespace:
+    """Install the runtime service-registry boundary missing from the HA class spec."""
+    registry = SimpleNamespace(
+        has_service=MagicMock(),
+        async_register=MagicMock(),
+        async_remove=MagicMock(),
+    )
+    hass.services = registry
+    return registry
+
+
+def _capture_registered_services(hass: MagicMock) -> dict[str, RegisteredService]:
+    """Register services and return their captured handlers and schemas."""
+    registry = _service_registry(hass)
+    registry.has_service.return_value = False
+    services_module.async_register_services(hass)
+
+    registered: dict[str, RegisteredService] = {}
+    for registration in registry.async_register.call_args_list:
+        domain, service_name, handler = registration.args
+        assert domain == DOMAIN
+        registered[service_name] = RegisteredService(
+            handler=handler,
+            schema=registration.kwargs["schema"],
+            supports_response=registration.kwargs.get(
+                "supports_response", SupportsResponse.NONE
+            ),
+        )
+    return registered
+
+
+@pytest.fixture
+def registered_services(hass_mock: MagicMock) -> dict[str, RegisteredService]:
+    """Return all services registered against the Home Assistant boundary."""
+    return _capture_registered_services(hass_mock)
+
+
+def _install_coordinators(hass: MagicMock, *coordinators: SimpleNamespace) -> None:
+    """Install coordinators into Home Assistant integration storage."""
+    hass.data[DOMAIN] = {
+        f"entry-{index}": coordinator
+        for index, coordinator in enumerate(coordinators, start=1)
+    }
+
+
+async def _call_service(
+    hass: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+    service_name: str,
+    data: dict[str, Any] | None = None,
+) -> Any:
+    """Validate service data and invoke the captured Home Assistant handler."""
+    service = registered_services[service_name]
+    validated_data = service.schema(data or {})
+    service_call = ServiceCall(
+        hass,
+        DOMAIN,
+        service_name,
+        validated_data,
+        return_response=service.supports_response is SupportsResponse.ONLY,
+    )
+    return await service.handler(service_call)
+
+
+def test_model_to_response_serializes_models_in_json_mode() -> None:
+    """Model responses must request JSON-safe values for Home Assistant."""
+    model = ModelResponse({"status": "ready"})
+
+    assert services_module._model_to_response(model) == {"status": "ready"}
+    assert model.mode == "json"
+
+
+def test_model_to_response_preserves_mapping_responses() -> None:
+    """Already-normalized mapping responses must be returned unchanged."""
+    response = {"items": ["one", "two"]}
+
+    assert services_module._model_to_response(response) is response
+
+
+@pytest.mark.parametrize("value", [None, True, "ready", ["one"]])
+def test_model_to_response_wraps_non_mapping_values(value: object) -> None:
+    """Scalar and sequence responses must receive a stable response key."""
+    assert services_module._model_to_response(value) == {"value": value}
+
+
+def test_pro_gate_accepts_pro_hardware() -> None:
+    """Pro services must accept coordinators reporting Pro hardware."""
+    services_module._ensure_pro(
+        SimpleNamespace(is_pro_hardware=True), SERVICE_SCAN_WIFI
+    )
+
+
+def test_pro_gate_rejects_other_hardware() -> None:
+    """Pro services must expose a user-facing hardware error."""
+    with pytest.raises(
+        HomeAssistantError,
+        match="The scan_wifi service is only available for NanoKVM Pro devices",
+    ):
+        services_module._ensure_pro(
+            SimpleNamespace(is_pro_hardware=False), SERVICE_SCAN_WIFI
+        )
+
+
+def test_service_schemas_apply_defaults_and_coercion() -> None:
+    """Service schemas must apply documented defaults before handler execution."""
+    assert services_module.PUSH_BUTTON_SCHEMA(
+        {ATTR_BUTTON_TYPE: BUTTON_TYPE_POWER}
+    ) == {
+        ATTR_BUTTON_TYPE: BUTTON_TYPE_POWER,
+        ATTR_DURATION: 100,
+    }
+    assert (
+        services_module.PUSH_BUTTON_SCHEMA(
+            {ATTR_BUTTON_TYPE: BUTTON_TYPE_RESET, ATTR_DURATION: "250"}
+        )[ATTR_DURATION]
+        == 250
+    )
+    assert services_module.SET_MOUSE_JIGGLER_SCHEMA({ATTR_ENABLED: True}) == {
+        ATTR_ENABLED: True,
+        ATTR_MODE: "absolute",
+    }
+
+
+@pytest.mark.parametrize(
+    ("schema", "data"),
+    [
+        (
+            services_module.PUSH_BUTTON_SCHEMA,
+            {ATTR_BUTTON_TYPE: BUTTON_TYPE_POWER, ATTR_DURATION: 99},
+        ),
+        (services_module.HOST_ONLY_SCHEMA, {CONF_HOST: ""}),
+        (
+            services_module.SET_MOUSE_JIGGLER_SCHEMA,
+            {ATTR_ENABLED: True, ATTR_MODE: "bad"},
+        ),
+        (services_module.SET_LED_STRIP_SCHEMA, {ATTR_BRIGHTNESS: 101}),
+    ],
+)
+def test_service_schemas_reject_invalid_fields(
+    schema: vol.Schema, data: dict[str, Any]
+) -> None:
+    """Invalid user input must fail before reaching a device handler."""
+    with pytest.raises(vol.Invalid):
+        schema(data)
+
+
+def test_register_services_registers_complete_surface_with_response_contracts(
+    hass_mock: MagicMock,
+) -> None:
+    """Registration must expose every implementation service exactly once."""
+    registered = _capture_registered_services(hass_mock)
+
+    assert tuple(registered) == services_module._SERVICE_NAMES
+    assert {
+        name
+        for name, service in registered.items()
+        if service.supports_response is SupportsResponse.ONLY
+    } == {
+        SERVICE_SCAN_WIFI,
+        SERVICE_LIST_IMAGES,
+        SERVICE_IMAGE_DOWNLOAD_ENABLED,
+        SERVICE_GET_IMAGE_DOWNLOAD_STATUS,
+        SERVICE_LIST_CUSTOM_EDIDS,
+    }
+    assert all(service.schema is not None for service in registered.values())
+
+
+def test_register_services_is_idempotent_when_already_registered(
+    hass_mock: MagicMock,
+) -> None:
+    """Repeated setup must not replace existing service handlers."""
+    registry = _service_registry(hass_mock)
+    registry.has_service.return_value = True
+
+    services_module.async_register_services(hass_mock)
+
+    registry.async_register.assert_not_called()
+
+
+async def test_target_resolution_rejects_empty_configuration(
+    hass_mock: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+) -> None:
+    """A service call must fail clearly when no device is configured."""
+    with pytest.raises(HomeAssistantError, match="No NanoKVM devices are configured"):
+        await _call_service(hass_mock, registered_services, SERVICE_REBOOT)
+
+
+async def test_target_resolution_uses_only_device_when_host_is_omitted(
+    hass_mock: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+) -> None:
+    """A single configured device must not require an explicit host."""
+    coordinator = _coordinator()
+    _install_coordinators(hass_mock, coordinator)
+
+    await _call_service(hass_mock, registered_services, SERVICE_REBOOT)
+
+    coordinator.client.reboot_system.assert_awaited_once_with()
+
+
+async def test_target_resolution_requires_host_for_multiple_devices(
+    hass_mock: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+) -> None:
+    """Ambiguous multi-device calls must ask for an explicit target."""
+    _install_coordinators(
+        hass_mock,
+        _coordinator("first.local"),
+        _coordinator("second.local"),
+    )
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="Multiple NanoKVM devices are configured; specify the host field",
+    ):
+        await _call_service(hass_mock, registered_services, SERVICE_REBOOT)
+
+
+async def test_target_resolution_matches_normalized_host_forms(
+    hass_mock: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+) -> None:
+    """Equivalent bare, HTTP, and HTTPS host forms must target one device."""
+    first = _coordinator("first.local")
+    selected = _coordinator("http://nanokvm.local/api/")
+    _install_coordinators(hass_mock, first, selected)
+
+    await _call_service(
+        hass_mock,
+        registered_services,
+        SERVICE_REBOOT,
+        {CONF_HOST: "https://nanokvm.local"},
+    )
+
+    first.client.reboot_system.assert_not_awaited()
+    selected.client.reboot_system.assert_awaited_once_with()
+
+
+async def test_target_resolution_rejects_unknown_host(
+    hass_mock: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+) -> None:
+    """An unknown explicit host must not fall back to another device."""
+    _install_coordinators(hass_mock, _coordinator("configured.local"))
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="No NanoKVM device is configured for host missing.local",
+    ):
+        await _call_service(
+            hass_mock,
+            registered_services,
+            SERVICE_REBOOT,
+            {CONF_HOST: "missing.local"},
+        )
+
+
+async def test_target_resolution_rejects_duplicate_normalized_hosts(
+    hass_mock: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+) -> None:
+    """Duplicate normalized host entries must remain explicitly ambiguous."""
+    _install_coordinators(
+        hass_mock,
+        _coordinator("http://duplicate.local"),
+        _coordinator("https://duplicate.local/api/"),
+    )
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="Multiple NanoKVM devices match host duplicate.local",
+    ):
+        await _call_service(
+            hass_mock,
+            registered_services,
+            SERVICE_REBOOT,
+            {CONF_HOST: "duplicate.local"},
+        )
+
+
+@pytest.mark.parametrize(
+    ("button_type", "expected_gpio"),
+    [
+        (BUTTON_TYPE_POWER, services_module.GpioType.POWER),
+        (BUTTON_TYPE_RESET, services_module.GpioType.RESET),
+    ],
+)
+async def test_push_button_maps_service_type_and_duration(
+    hass_mock: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+    button_type: str,
+    expected_gpio: services_module.GpioType,
+) -> None:
+    """Push-button calls must map UI values to library enum arguments."""
+    coordinator = _coordinator()
+    _install_coordinators(hass_mock, coordinator)
+
+    await _call_service(
+        hass_mock,
+        registered_services,
+        SERVICE_PUSH_BUTTON,
+        {ATTR_BUTTON_TYPE: button_type, ATTR_DURATION: 750},
+    )
+
+    coordinator.client.push_button.assert_awaited_once_with(expected_gpio, 750)
+
+
+async def test_paste_text_forwards_exact_text(
+    hass_mock: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+) -> None:
+    """Paste service text must reach the NanoKVM client unchanged."""
+    coordinator = _coordinator()
+    _install_coordinators(hass_mock, coordinator)
+
+    await _call_service(
+        hass_mock,
+        registered_services,
+        SERVICE_PASTE_TEXT,
+        {ATTR_TEXT: "Hello, NanoKVM!"},
+    )
+
+    coordinator.client.paste_text.assert_awaited_once_with("Hello, NanoKVM!")
+
+
+@pytest.mark.parametrize(
+    ("service_name", "client_method"),
+    [
+        (SERVICE_REBOOT, "reboot_system"),
+        (SERVICE_RESET_HDMI, "reset_hdmi"),
+        (SERVICE_RESET_HID, "reset_hid"),
+    ],
+)
+async def test_no_argument_services_invoke_expected_client_method(
+    hass_mock: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+    service_name: str,
+    client_method: str,
+) -> None:
+    """Simple service handlers must invoke their corresponding API method."""
+    coordinator = _coordinator()
+    _install_coordinators(hass_mock, coordinator)
+
+    await _call_service(hass_mock, registered_services, service_name)
+
+    getattr(coordinator.client, client_method).assert_awaited_once_with()
+
+
+async def test_wake_on_lan_forwards_mac_address(
+    hass_mock: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+) -> None:
+    """Wake-on-LAN must forward the requested MAC address unchanged."""
+    coordinator = _coordinator()
+    _install_coordinators(hass_mock, coordinator)
+
+    await _call_service(
+        hass_mock,
+        registered_services,
+        SERVICE_WAKE_ON_LAN,
+        {ATTR_MAC: "00:11:22:33:44:55"},
+    )
+
+    coordinator.client.send_wake_on_lan.assert_awaited_once_with("00:11:22:33:44:55")
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_mode"),
+    [
+        ("absolute", services_module.MouseJigglerMode.ABSOLUTE),
+        ("relative", services_module.MouseJigglerMode.RELATIVE),
+    ],
+)
+async def test_mouse_jiggler_maps_mode_enum(
+    hass_mock: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+    mode: str,
+    expected_mode: services_module.MouseJigglerMode,
+) -> None:
+    """Mouse-jiggler mode strings must map to library enums."""
+    coordinator = _coordinator()
+    _install_coordinators(hass_mock, coordinator)
+
+    await _call_service(
+        hass_mock,
+        registered_services,
+        SERVICE_SET_MOUSE_JIGGLER,
+        {ATTR_ENABLED: False, ATTR_MODE: mode},
+    )
+
+    coordinator.client.set_mouse_jiggler_state.assert_awaited_once_with(
+        False, expected_mode
+    )
+
+
+async def test_led_strip_requires_at_least_one_update_field(
+    hass_mock: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+) -> None:
+    """An empty LED update must fail before resolving or contacting a device."""
+    _install_coordinators(hass_mock, _coordinator(is_pro_hardware=True))
+
+    with pytest.raises(
+        HomeAssistantError, match="At least one LED strip field is required"
+    ):
+        await _call_service(hass_mock, registered_services, SERVICE_SET_LED_STRIP)
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        (
+            {ATTR_ON: False},
+            {
+                "on": False,
+                "brightness": 75,
+                "horizontal_count": 30,
+                "vertical_count": 20,
+            },
+        ),
+        (
+            {ATTR_VERTICAL_COUNT: 25},
+            {
+                "on": True,
+                "brightness": 75,
+                "horizontal_count": 30,
+                "vertical_count": 25,
+            },
+        ),
+    ],
+)
+async def test_led_strip_merges_partial_updates_and_refreshes(
+    hass_mock: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+    data: dict[str, Any],
+    expected: dict[str, Any],
+) -> None:
+    """LED updates must preserve unspecified device state and refresh afterward."""
+    coordinator = _coordinator(
+        is_pro_hardware=True,
+        led_strip=GetLedStripRsp(on=True, hor=30, ver=20, brightness=75),
+    )
+    _install_coordinators(hass_mock, coordinator)
+
+    await _call_service(hass_mock, registered_services, SERVICE_SET_LED_STRIP, data)
+
+    coordinator.client.set_led_strip.assert_awaited_once_with(**expected)
+    coordinator.async_request_refresh.assert_awaited_once_with()
+
+
+async def test_led_strip_translates_invalid_merged_config(
+    hass_mock: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+) -> None:
+    """Invalid aggregate bead counts must become a user-facing HA error."""
+    coordinator = _coordinator(
+        is_pro_hardware=True,
+        led_strip=GetLedStripRsp(on=True, hor=30, ver=20, brightness=75),
+    )
+    _install_coordinators(hass_mock, coordinator)
+
+    with pytest.raises(
+        HomeAssistantError,
+        match=r"horizontal_count \+ \(2 \* vertical_count\) <= 150",
+    ):
+        await _call_service(
+            hass_mock,
+            registered_services,
+            SERVICE_SET_LED_STRIP,
+            {ATTR_HORIZONTAL_COUNT: 120},
+        )
+
+    coordinator.client.set_led_strip.assert_not_awaited()
+    coordinator.async_request_refresh.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "service_name",
+    [SERVICE_SET_LED_STRIP, SERVICE_SCAN_WIFI, SERVICE_LIST_CUSTOM_EDIDS],
+)
+async def test_pro_services_reject_non_pro_devices(
+    hass_mock: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+    service_name: str,
+) -> None:
+    """Every Pro-only service must apply the same hardware gate."""
+    coordinator = _coordinator(
+        is_pro_hardware=False,
+        led_strip=GetLedStripRsp(on=True, hor=30, ver=20, brightness=75),
+    )
+    _install_coordinators(hass_mock, coordinator)
+    data = {ATTR_BRIGHTNESS: 50} if service_name == SERVICE_SET_LED_STRIP else {}
+
+    with pytest.raises(
+        HomeAssistantError,
+        match=rf"The {service_name} service is only available for NanoKVM Pro devices",
+    ):
+        await _call_service(hass_mock, registered_services, service_name, data)
+
+
+@pytest.mark.parametrize(
+    ("service_name", "client_method", "response", "expected"),
+    [
+        (
+            SERVICE_SCAN_WIFI,
+            "scan_wifi",
+            ScanWifiRsp(
+                wifiList=[
+                    WiFiInfo(
+                        ssid="Lab",
+                        bssid="00:11:22:33:44:55",
+                        signal=-40,
+                        frequency=2412,
+                        security="WPA2",
+                    )
+                ]
+            ),
+            {
+                "wifi_list": [
+                    {
+                        "ssid": "Lab",
+                        "bssid": "00:11:22:33:44:55",
+                        "signal": -40,
+                        "frequency": 2412,
+                        "security": "WPA2",
+                    }
+                ]
+            },
+        ),
+        (
+            SERVICE_LIST_IMAGES,
+            "get_images",
+            GetImagesRsp(files=["installer.iso"]),
+            {"files": ["installer.iso"]},
+        ),
+        (
+            SERVICE_IMAGE_DOWNLOAD_ENABLED,
+            "is_image_download_enabled",
+            ImageEnabledRsp(enabled=True),
+            {"enabled": True},
+        ),
+        (
+            SERVICE_GET_IMAGE_DOWNLOAD_STATUS,
+            "get_image_download_status",
+            StatusImageRsp(
+                status=DownloadStatus.IN_PROGRESS,
+                file="installer.iso",
+                percentage="25",
+            ),
+            {
+                "status": "in_progress",
+                "file": "installer.iso",
+                "percentage": "25",
+            },
+        ),
+        (
+            SERVICE_LIST_CUSTOM_EDIDS,
+            "get_custom_edid_list",
+            GetCustomEdidListRsp(edidList=["display.bin"]),
+            {"edid_list": ["display.bin"]},
+        ),
+    ],
+)
+async def test_response_services_return_json_ready_models(
+    hass_mock: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+    service_name: str,
+    client_method: str,
+    response: object,
+    expected: dict[str, Any],
+) -> None:
+    """Response handlers must normalize library models for HA service callers."""
+    coordinator = _coordinator(is_pro_hardware=True)
+    getattr(coordinator.client, client_method).return_value = response
+    _install_coordinators(hass_mock, coordinator)
+
+    result = await _call_service(hass_mock, registered_services, service_name)
+
+    assert result == expected
+    getattr(coordinator.client, client_method).assert_awaited_once_with()
+
+
+async def test_non_response_handler_preserves_home_assistant_errors(
+    hass_mock: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+) -> None:
+    """Already-user-facing errors must not be wrapped a second time."""
+    coordinator = _coordinator()
+    original_error = HomeAssistantError("friendly device error")
+    coordinator.client.paste_text.side_effect = original_error
+    _install_coordinators(hass_mock, coordinator)
+
+    with pytest.raises(HomeAssistantError) as captured:
+        await _call_service(
+            hass_mock,
+            registered_services,
+            SERVICE_PASTE_TEXT,
+            {ATTR_TEXT: "text"},
+        )
+
+    assert captured.value is original_error
+
+
+async def test_non_response_handler_translates_unexpected_errors(
+    hass_mock: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+) -> None:
+    """Unexpected client failures must include service and host context."""
+    coordinator = _coordinator()
+    coordinator.client.paste_text.side_effect = RuntimeError("offline")
+    _install_coordinators(hass_mock, coordinator)
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="Failed to execute paste_text for nanokvm.local: offline",
+    ) as captured:
+        await _call_service(
+            hass_mock,
+            registered_services,
+            SERVICE_PASTE_TEXT,
+            {ATTR_TEXT: "text"},
+        )
+
+    assert isinstance(captured.value.__cause__, RuntimeError)
+
+
+async def test_client_context_failures_are_translated_with_unknown_host_fallback(
+    hass_mock: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+) -> None:
+    """Client-access failures must use a stable host fallback for malformed entries."""
+    coordinator = _coordinator(
+        host=None,
+        context_error=RuntimeError("session failed"),
+    )
+    _install_coordinators(hass_mock, coordinator)
+
+    with pytest.raises(
+        HomeAssistantError,
+        match=r"Failed to execute reboot for <unknown>: session failed",
+    ):
+        await _call_service(hass_mock, registered_services, SERVICE_REBOOT)
+
+
+async def test_response_handler_translates_unexpected_errors(
+    hass_mock: MagicMock,
+    registered_services: Mapping[str, RegisteredService],
+) -> None:
+    """Response-service failures must use the same user-facing error contract."""
+    coordinator = _coordinator()
+    coordinator.client.get_images.side_effect = RuntimeError("storage unavailable")
+    _install_coordinators(hass_mock, coordinator)
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="Failed to execute list_images for nanokvm.local: storage unavailable",
+    ) as captured:
+        await _call_service(hass_mock, registered_services, SERVICE_LIST_IMAGES)
+
+    assert isinstance(captured.value.__cause__, RuntimeError)
+
+
+def test_unregister_services_removes_only_registered_services(
+    hass_mock: MagicMock,
+) -> None:
+    """Unload must remove every currently registered integration service."""
+    registered_names = {SERVICE_REBOOT, SERVICE_SCAN_WIFI, SERVICE_LIST_IMAGES}
+    registry = _service_registry(hass_mock)
+    registry.has_service.side_effect = lambda domain, service_name: (
+        domain == DOMAIN and service_name in registered_names
+    )
+
+    services_module.async_unregister_services(hass_mock)
+
+    assert registry.async_remove.call_args_list == [
+        call(DOMAIN, service_name)
+        for service_name in services_module._SERVICE_NAMES
+        if service_name in registered_names
+    ]
+
+
+def test_unregister_services_is_noop_when_none_are_registered(
+    hass_mock: MagicMock,
+) -> None:
+    """Unload must tolerate an already-empty service registry."""
+    registry = _service_registry(hass_mock)
+    registry.has_service.return_value = False
+
+    services_module.async_unregister_services(hass_mock)
+
+    registry.async_remove.assert_not_called()

--- a/tests/platforms/test_platform_actions.py
+++ b/tests/platforms/test_platform_actions.py
@@ -1,0 +1,596 @@
+"""Tests for platform entity actions and Home Assistant-facing properties."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+from homeassistant.exceptions import HomeAssistantError
+from nanokvm.models import (
+    DiskType,
+    HidMode,
+    LcdTimeFormat,
+    MouseJigglerMode,
+    VirtualDevice,
+)
+import pytest
+from yarl import URL
+
+import custom_components.nanokvm.binary_sensor as binary_sensor_module
+import custom_components.nanokvm.button as button_module
+import custom_components.nanokvm.number as number_module
+import custom_components.nanokvm.select as select_module
+import custom_components.nanokvm.sensor as sensor_module
+import custom_components.nanokvm.switch as switch_module
+import custom_components.nanokvm.update as update_module
+
+
+def _coordinator(**overrides: object) -> SimpleNamespace:
+    """Build a coordinator with a serialized client boundary and async actions."""
+    client = MagicMock()
+    client.url = URL("http://nanokvm.local/api/")
+
+    @asynccontextmanager
+    async def async_client() -> AsyncIterator[MagicMock]:
+        yield client
+
+    values: dict[str, object] = {
+        "application_version_info": SimpleNamespace(current="1.0.0", latest="1.1.0"),
+        "async_client": MagicMock(side_effect=async_client),
+        "async_ensure_ssh_metrics_collector": AsyncMock(),
+        "async_request_refresh": AsyncMock(),
+        "client": client,
+        "device_info": SimpleNamespace(application="1.0.0", device_key="test-device"),
+        "gpio_info": SimpleNamespace(pwr=True, hdd=False),
+        "hardware_info": None,
+        "hostname_info": None,
+        "is_pro_hardware": True,
+        "last_update_success": True,
+        "led_strip": SimpleNamespace(
+            on=True,
+            brightness=75,
+            horizontal_count=30,
+            vertical_count=20,
+        ),
+        "virtual_device_info": SimpleNamespace(network=False, disk=False, mic=False),
+        "watchdog_enabled": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _description(descriptions: tuple[object, ...], key: str) -> object:
+    """Return one entity description by key."""
+    return next(item for item in descriptions if item.key == key)
+
+
+@pytest.mark.asyncio
+async def test_button_press_uses_serialized_client_and_refreshes() -> None:
+    """Button actions must execute through coordinator client access and refresh."""
+    coordinator = _coordinator()
+    coordinator.client.reboot_system = AsyncMock()
+    entity = button_module.NanoKVMButton(
+        coordinator,
+        _description(button_module.BUTTONS, "reboot"),
+    )
+
+    await entity.async_press()
+
+    coordinator.async_client.assert_called_once_with()
+    coordinator.client.reboot_system.assert_awaited_once_with()
+    coordinator.async_request_refresh.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_button_without_handler_raises() -> None:
+    """A malformed button description must fail clearly instead of doing nothing."""
+    entity = button_module.NanoKVMButton(
+        _coordinator(),
+        button_module.NanoKVMButtonEntityDescription(key="missing"),
+    )
+
+    with pytest.raises(RuntimeError, match="Missing press handler for button: missing"):
+        await entity.async_press()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("key", "value", "expected"),
+    [
+        (
+            "led_brightness",
+            25.9,
+            {
+                "on": True,
+                "brightness": 25,
+                "horizontal_count": 30,
+                "vertical_count": 20,
+            },
+        ),
+        (
+            "led_horizontal_beads",
+            40.9,
+            {
+                "on": True,
+                "brightness": 75,
+                "horizontal_count": 40,
+                "vertical_count": 20,
+            },
+        ),
+        (
+            "led_vertical_beads",
+            30.9,
+            {
+                "on": True,
+                "brightness": 75,
+                "horizontal_count": 30,
+                "vertical_count": 30,
+            },
+        ),
+    ],
+)
+async def test_number_actions_preserve_led_state_and_refresh(
+    key: str,
+    value: float,
+    expected: dict[str, object],
+) -> None:
+    """Each LED number must update one integer field and preserve the others."""
+    coordinator = _coordinator()
+    coordinator.client.set_led_strip = AsyncMock()
+    entity = number_module.NanoKVMNumber(
+        coordinator,
+        _description(number_module.NUMBERS, key),
+    )
+
+    await entity.async_set_native_value(value)
+
+    coordinator.client.set_led_strip.assert_awaited_once_with(**expected)
+    coordinator.async_request_refresh.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_number_validation_error_becomes_home_assistant_error() -> None:
+    """Invalid LED values must surface as a Home Assistant service error."""
+    coordinator = _coordinator()
+    entity = number_module.NanoKVMNumber(
+        coordinator,
+        _description(number_module.NUMBERS, "led_brightness"),
+    )
+
+    with pytest.raises(HomeAssistantError, match="LED brightness"):
+        await entity.async_set_native_value(101)
+
+    coordinator.async_request_refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_number_without_handler_raises() -> None:
+    """A malformed number description must fail before client access."""
+    entity = number_module.NanoKVMNumber(
+        _coordinator(),
+        number_module.NanoKVMNumberEntityDescription(key="missing"),
+    )
+
+    with pytest.raises(
+        RuntimeError, match="Missing number handler for number: missing"
+    ):
+        await entity.async_set_native_value(1)
+
+
+def test_number_entity_exposes_dynamic_value_bounds_and_availability() -> None:
+    """Number properties must delegate to the description and coordinator health."""
+    coordinator = _coordinator()
+    entity = number_module.NanoKVMNumber(
+        coordinator,
+        _description(number_module.NUMBERS, "led_horizontal_beads"),
+    )
+
+    assert entity.available is True
+    assert entity.native_value == 30
+    assert entity.native_min_value == 1
+    assert entity.native_max_value == 110
+
+    coordinator.last_update_success = False
+    assert entity.available is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("key", "option", "method", "expected_args", "expected_kwargs"),
+    [
+        ("hid_mode", "hid_only", "set_hid_mode", (HidMode.HID_ONLY,), {}),
+        ("hid_mode", "unknown", "set_hid_mode", (HidMode.NORMAL,), {}),
+        (
+            "mouse_jiggler_mode",
+            "relative_mode",
+            "set_mouse_jiggler_state",
+            (True, MouseJigglerMode.RELATIVE),
+            {},
+        ),
+        (
+            "mouse_jiggler_mode",
+            "disable",
+            "set_mouse_jiggler_state",
+            (False, MouseJigglerMode.ABSOLUTE),
+            {},
+        ),
+        ("oled_sleep_timeout", "30_sec", "set_oled_sleep", (30,), {}),
+        ("oled_sleep_timeout", "unknown", "set_oled_sleep", (0,), {}),
+        ("swap_size", "128_mb", "set_swap_size", (128,), {}),
+        ("swap_size", "unknown", "set_swap_size", (0,), {}),
+        (
+            "lcd_time_format",
+            "12h",
+            "set_lcd_time_format",
+            (LcdTimeFormat.TWELVE_HOUR,),
+            {},
+        ),
+        (
+            "lcd_time_format",
+            "unknown",
+            "set_lcd_time_format",
+            (LcdTimeFormat.TWENTY_FOUR_HOUR,),
+            {},
+        ),
+        (
+            "virtual_disk_type",
+            "sdcard",
+            "update_virtual_device",
+            (VirtualDevice.DISK,),
+            {"disk_type": DiskType.SDCARD},
+        ),
+        (
+            "virtual_disk_type",
+            "unknown",
+            "update_virtual_device",
+            (VirtualDevice.DISK,),
+            {"disk_type": DiskType.EMMC},
+        ),
+    ],
+)
+async def test_select_actions_map_options_and_refresh(
+    key: str,
+    option: str,
+    method: str,
+    expected_args: tuple[object, ...],
+    expected_kwargs: dict[str, object],
+) -> None:
+    """Select option keys must map to the exact library API values."""
+    coordinator = _coordinator()
+    client_method = AsyncMock()
+    setattr(coordinator.client, method, client_method)
+    entity = select_module.NanoKVMSelect(
+        coordinator,
+        _description(select_module.SELECTS, key),
+    )
+
+    await entity.async_select_option(option)
+
+    client_method.assert_awaited_once_with(*expected_args, **expected_kwargs)
+    coordinator.async_request_refresh.assert_awaited_once_with()
+
+
+def test_select_entity_exposes_static_and_dynamic_options() -> None:
+    """Select entities must expose description values and runtime disk options."""
+    static = select_module.NanoKVMSelect(
+        _coordinator(hid_mode=SimpleNamespace(mode=HidMode.HID_ONLY)),
+        _description(select_module.SELECTS, "hid_mode"),
+    )
+    dynamic = select_module.NanoKVMSelect(
+        _coordinator(
+            virtual_device_info=SimpleNamespace(
+                is_emmc_exist=True,
+                is_sd_card_exist=False,
+                mounted_disk="emmc",
+            )
+        ),
+        _description(select_module.SELECTS, "virtual_disk_type"),
+    )
+
+    assert static.current_option == "hid_only"
+    assert static.options == ["normal", "hid_only"]
+    assert dynamic.current_option == "emmc"
+    assert dynamic.options == ["emmc"]
+
+
+@pytest.mark.asyncio
+async def test_select_without_handler_raises() -> None:
+    """A malformed select description must fail before client access."""
+    entity = select_module.NanoKVMSelect(
+        _coordinator(),
+        select_module.NanoKVMSelectEntityDescription(key="missing"),
+    )
+
+    with pytest.raises(
+        RuntimeError, match="Missing select handler for select: missing"
+    ):
+        await entity.async_select_option("anything")
+
+
+def test_binary_sensor_and_sensor_entities_expose_coordinator_data() -> None:
+    """Read-only entities must combine coordinator health with description behavior."""
+    coordinator = _coordinator(value=True, attributes={"detail": "ready"})
+    binary = binary_sensor_module.NanoKVMBinarySensor(
+        coordinator,
+        binary_sensor_module.NanoKVMBinarySensorEntityDescription(
+            key="test",
+            value_fn=lambda state: state.value,
+            available_fn=lambda state: state.value,
+        ),
+    )
+    sensor = sensor_module.NanoKVMSensor(
+        coordinator,
+        sensor_module.NanoKVMSensorEntityDescription(
+            key="test",
+            value_fn=lambda state: "online" if state.value else "offline",
+            available_fn=lambda state: state.value,
+            attributes_fn=lambda state: state.attributes,
+        ),
+    )
+
+    assert binary.is_on is True
+    assert binary.available is True
+    assert sensor.native_value == "online"
+    assert sensor.available is True
+    assert sensor.extra_state_attributes == {"detail": "ready"}
+
+    coordinator.last_update_success = False
+    assert binary.available is False
+    assert sensor.available is False
+
+
+@pytest.mark.asyncio
+async def test_generic_switch_actions_use_handlers_and_refresh() -> None:
+    """Generic switches must execute both handlers through serialized client access."""
+    coordinator = _coordinator(ssh_state=SimpleNamespace(enabled=False))
+    coordinator.client.enable_ssh = AsyncMock()
+    coordinator.client.disable_ssh = AsyncMock()
+    entity = switch_module.NanoKVMSwitch(
+        coordinator,
+        _description(switch_module.SWITCHES, "ssh"),
+    )
+
+    await entity.async_turn_on()
+    await entity.async_turn_off()
+
+    coordinator.client.enable_ssh.assert_awaited_once_with()
+    coordinator.client.disable_ssh.assert_awaited_once_with()
+    assert coordinator.async_request_refresh.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_generic_switch_missing_handlers_raise() -> None:
+    """Malformed generic switch descriptions must fail clearly."""
+    entity = switch_module.NanoKVMSwitch(
+        _coordinator(),
+        switch_module.NanoKVMSwitchEntityDescription(key="missing"),
+    )
+
+    with pytest.raises(RuntimeError, match="Missing turn_on handler"):
+        await entity.async_turn_on()
+    with pytest.raises(RuntimeError, match="Missing turn_off handler"):
+        await entity.async_turn_off()
+
+
+@pytest.mark.asyncio
+async def test_led_switch_preserves_strip_values_and_translates_missing_state() -> None:
+    """LED power writes must preserve strip geometry and report unavailable state."""
+    coordinator = _coordinator()
+    coordinator.client.set_led_strip = AsyncMock()
+
+    await switch_module._set_led_strip_on(coordinator, False)
+
+    coordinator.client.set_led_strip.assert_awaited_once_with(
+        on=False,
+        brightness=75,
+        horizontal_count=30,
+        vertical_count=20,
+    )
+
+    coordinator.led_strip = None
+    with pytest.raises(HomeAssistantError, match="LED strip state is unavailable"):
+        await switch_module._set_led_strip_on(coordinator, True)
+
+
+@pytest.mark.asyncio
+async def test_power_state_refresh_handles_unavailable_gpio() -> None:
+    """Power state refresh must return None when GPIO polling is unavailable."""
+    entity = switch_module.NanoKVMPowerSwitch(
+        _coordinator(gpio_info=None),
+        _description(switch_module.SWITCHES, "power"),
+    )
+
+    assert await entity._async_current_power_state() is None
+
+
+@pytest.mark.asyncio
+async def test_power_switch_missing_handlers_raise() -> None:
+    """Malformed power descriptions must fail before polling or client access."""
+    entity = switch_module.NanoKVMPowerSwitch(
+        _coordinator(),
+        switch_module.NanoKVMSwitchEntityDescription(key="power"),
+    )
+
+    with pytest.raises(RuntimeError, match="Missing turn_on handler"):
+        await entity.async_turn_on()
+    with pytest.raises(RuntimeError, match="Missing turn_off handler"):
+        await entity.async_turn_off()
+
+
+@pytest.mark.asyncio
+async def test_power_turn_off_presses_once_and_returns_when_gpio_turns_off() -> None:
+    """Power-off monitoring must stop once a refreshed GPIO state is off."""
+    coordinator = _coordinator()
+    coordinator.client.push_button = AsyncMock()
+
+    async def refresh() -> None:
+        if coordinator.async_request_refresh.await_count == 2:
+            coordinator.gpio_info.pwr = False
+
+    coordinator.async_request_refresh.side_effect = refresh
+    entity = switch_module.NanoKVMPowerSwitch(
+        coordinator,
+        _description(switch_module.SWITCHES, "power"),
+    )
+    loop = MagicMock()
+    loop.time.side_effect = [0, 0]
+    entity.hass = SimpleNamespace(loop=loop)
+
+    await entity.async_turn_off()
+
+    coordinator.client.push_button.assert_awaited_once()
+    assert coordinator.async_request_refresh.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_power_turn_off_refreshes_after_timeout() -> None:
+    """Power-off timeout must perform a final refresh without sleeping."""
+    coordinator = _coordinator()
+    coordinator.client.push_button = AsyncMock()
+    entity = switch_module.NanoKVMPowerSwitch(
+        coordinator,
+        _description(switch_module.SWITCHES, "power"),
+    )
+    loop = MagicMock()
+    loop.time.side_effect = [0, 301]
+    entity.hass = SimpleNamespace(loop=loop)
+
+    await entity.async_turn_off()
+
+    coordinator.client.push_button.assert_awaited_once()
+    assert coordinator.async_request_refresh.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_power_turn_off_sleeps_between_unsuccessful_polls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Power-off monitoring must delay between polls while GPIO remains on."""
+    coordinator = _coordinator()
+    coordinator.client.push_button = AsyncMock()
+    sleep = AsyncMock()
+    monkeypatch.setattr(switch_module.asyncio, "sleep", sleep)
+    entity = switch_module.NanoKVMPowerSwitch(
+        coordinator,
+        _description(switch_module.SWITCHES, "power"),
+    )
+    loop = MagicMock()
+    loop.time.side_effect = [0, 0, 301]
+    entity.hass = SimpleNamespace(loop=loop)
+
+    await entity.async_turn_off()
+
+    sleep.assert_awaited_once_with(5)
+    assert coordinator.async_request_refresh.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_virtual_device_switch_toggles_only_when_state_differs() -> None:
+    """Toggle-only virtual device APIs must not be called for an achieved state."""
+    coordinator = _coordinator(
+        virtual_device_info=SimpleNamespace(network=False, disk=False, mic=False)
+    )
+    coordinator.client.update_virtual_device = AsyncMock()
+    entity = switch_module.NanoKVMVirtualDeviceSwitch(
+        coordinator,
+        _description(switch_module.SWITCHES, "virtual_network"),
+    )
+
+    await entity.async_turn_on()
+    coordinator.client.update_virtual_device.assert_awaited_once_with(
+        VirtualDevice.NETWORK
+    )
+    assert coordinator.async_request_refresh.await_count == 2
+
+    coordinator.async_request_refresh.reset_mock()
+    coordinator.client.update_virtual_device.reset_mock()
+    coordinator.virtual_device_info.network = True
+    await entity.async_turn_on()
+    coordinator.client.update_virtual_device.assert_not_awaited()
+    coordinator.async_request_refresh.assert_awaited_once_with()
+
+    coordinator.virtual_device_info.network = True
+    await entity.async_turn_off()
+    coordinator.client.update_virtual_device.assert_awaited_once_with(
+        VirtualDevice.NETWORK
+    )
+
+
+@pytest.mark.asyncio
+async def test_virtual_device_switch_requires_device_type() -> None:
+    """A malformed virtual-device description must fail before refresh."""
+    entity = switch_module.NanoKVMVirtualDeviceSwitch(
+        _coordinator(),
+        switch_module.NanoKVMSwitchEntityDescription(key="missing"),
+    )
+
+    with pytest.raises(RuntimeError, match="Missing virtual device type"):
+        await entity.async_turn_on()
+
+
+@pytest.mark.asyncio
+async def test_watchdog_switch_writes_both_states_through_collector() -> None:
+    """Watchdog actions must use the ensured SSH collector and refresh state."""
+    coordinator = _coordinator()
+    collector = SimpleNamespace(set_watchdog_enabled=AsyncMock())
+    coordinator.async_ensure_ssh_metrics_collector.return_value = collector
+    entity = switch_module.NanoKVMWatchdogSwitch(
+        coordinator,
+        switch_module.SSH_SWITCHES[0],
+    )
+
+    await entity.async_turn_on()
+    await entity.async_turn_off()
+
+    assert collector.set_watchdog_enabled.await_args_list[0].args == (True,)
+    assert collector.set_watchdog_enabled.await_args_list[1].args == (False,)
+    assert coordinator.async_request_refresh.await_count == 2
+
+
+def _update_entity(coordinator: SimpleNamespace) -> update_module.NanoKVMUpdate:
+    """Create the application update entity."""
+    return update_module.NanoKVMUpdate(coordinator, update_module.UPDATES[0])
+
+
+@pytest.mark.asyncio
+async def test_update_install_calls_client_and_refreshes() -> None:
+    """Successful application updates must refresh coordinator state."""
+    coordinator = _coordinator()
+    coordinator.client.update_application = AsyncMock()
+
+    await _update_entity(coordinator).async_install(None, False, ignored=True)
+
+    coordinator.client.update_application.assert_awaited_once_with()
+    coordinator.async_request_refresh.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_update_install_accepts_expected_server_disconnect() -> None:
+    """A server disconnect after starting update must not become an HA error."""
+    coordinator = _coordinator()
+    coordinator.client.update_application = AsyncMock(
+        side_effect=aiohttp.ServerDisconnectedError("updating")
+    )
+
+    await _update_entity(coordinator).async_install("1.1.0", True)
+
+    coordinator.async_request_refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [aiohttp.ClientError("network"), TimeoutError("timeout")],
+)
+async def test_update_install_translates_client_failures(error: Exception) -> None:
+    """Known client failures must surface as Home Assistant errors."""
+    coordinator = _coordinator()
+    coordinator.client.update_application = AsyncMock(side_effect=error)
+
+    with pytest.raises(HomeAssistantError, match="Failed to start NanoKVM"):
+        await _update_entity(coordinator).async_install(None, False)
+
+    coordinator.async_request_refresh.assert_not_awaited()

--- a/tests/platforms/test_platform_setup.py
+++ b/tests/platforms/test_platform_setup.py
@@ -1,0 +1,421 @@
+"""Tests for Home Assistant platform setup and dynamic entity registration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from homeassistant.const import CONF_HOST
+from nanokvm.models import HWVersion
+import pytest
+from yarl import URL
+
+import custom_components.nanokvm.binary_sensor as binary_sensor_module
+import custom_components.nanokvm.button as button_module
+from custom_components.nanokvm.const import (
+    DOMAIN,
+    SIGNAL_NEW_MEDIA_ENTITIES,
+    SIGNAL_NEW_NETWORK_ENTITIES,
+    SIGNAL_NEW_SSH_SENSORS,
+    SIGNAL_NEW_SSH_SWITCHES,
+)
+import custom_components.nanokvm.number as number_module
+import custom_components.nanokvm.select as select_module
+import custom_components.nanokvm.sensor as sensor_module
+import custom_components.nanokvm.switch as switch_module
+import custom_components.nanokvm.update as update_module
+
+
+def _coordinator(**overrides: object) -> SimpleNamespace:
+    """Build a coordinator-shaped state object accepted by every platform."""
+    values: dict[str, object] = {
+        "application_version_info": SimpleNamespace(current="1.0.0", latest="1.1.0"),
+        "client": SimpleNamespace(url=URL("http://nanokvm.local/api/")),
+        "device_info": SimpleNamespace(
+            application="1.0.0",
+            device_key="test-device",
+            image="2026-01-01",
+            ips=[],
+        ),
+        "gpio_info": SimpleNamespace(pwr=False, hdd=False),
+        "hardware_info": None,
+        "hdmi_capture": None,
+        "hdmi_passthrough": None,
+        "hdmi_state": None,
+        "hid_mode": None,
+        "hostname_info": None,
+        "is_pro_hardware": False,
+        "last_update_success": True,
+        "lcd_time_format": None,
+        "led_strip": None,
+        "low_power": None,
+        "mdns_state": SimpleNamespace(enabled=False),
+        "mounted_image": None,
+        "mouse_jiggler_state": None,
+        "oled_info": None,
+        "ssh_sensors_created": False,
+        "ssh_state": SimpleNamespace(enabled=False),
+        "ssh_switches_created": False,
+        "static_ip": None,
+        "supports_cdrom_endpoint": False,
+        "supports_hdmi_endpoint": False,
+        "supports_non_pro_virtual_device_controls": False,
+        "supports_watchdog": False,
+        "swap_size": None,
+        "tailscale_status": None,
+        "time_status": None,
+        "virtual_device_info": None,
+        "watchdog_enabled": None,
+        "wifi_status": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _configure_hass(
+    hass_mock: MagicMock, config_entry_mock: MagicMock, coordinator: object
+) -> None:
+    """Store a coordinator under the entry like integration setup does."""
+    config_entry_mock.data[CONF_HOST] = "nanokvm.local"
+    hass_mock.data = {DOMAIN: {config_entry_mock.entry_id: coordinator}}
+
+
+def _entity_collector() -> tuple[Callable[[object], None], list[list[object]]]:
+    """Return an add-entities callback which eagerly materializes generators."""
+    batches: list[list[object]] = []
+
+    def add_entities(entities: object) -> None:
+        batches.append(list(entities))
+
+    return add_entities, batches
+
+
+def _capture_dispatchers(
+    monkeypatch: pytest.MonkeyPatch,
+    module: object,
+) -> dict[str, Callable[..., None]]:
+    """Capture dispatcher callbacks registered by a platform setup function."""
+    callbacks: dict[str, Callable[..., None]] = {}
+
+    def connect(
+        _hass: object, signal: str, callback: Callable[..., None]
+    ) -> Callable[[], None]:
+        callbacks[signal] = callback
+        return MagicMock()
+
+    monkeypatch.setattr(module, "async_dispatcher_connect", connect)
+    return callbacks
+
+
+@pytest.mark.asyncio
+async def test_binary_sensor_setup_adds_dynamic_media_and_network_entities_once(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Binary sensor setup must register initial and one-shot dynamic entities."""
+    coordinator = _coordinator()
+    _configure_hass(hass_mock, config_entry_mock, coordinator)
+    add_entities, batches = _entity_collector()
+    callbacks = _capture_dispatchers(monkeypatch, binary_sensor_module)
+
+    await binary_sensor_module.async_setup_entry(
+        hass_mock, config_entry_mock, add_entities
+    )
+
+    assert [
+        [entity.entity_description.key for entity in batch] for batch in batches
+    ] == [["power_led"]]
+    media_signal = SIGNAL_NEW_MEDIA_ENTITIES.format(config_entry_mock.entry_id)
+    network_signal = SIGNAL_NEW_NETWORK_ENTITIES.format(config_entry_mock.entry_id)
+    assert set(callbacks) == {media_signal, network_signal}
+    assert config_entry_mock.async_on_unload.call_count == 2
+
+    callbacks[media_signal]()
+    callbacks[network_signal]("wireless")
+    assert len(batches) == 1
+
+    coordinator.mounted_image = SimpleNamespace(file="/data/image.iso")
+    coordinator.supports_cdrom_endpoint = True
+    callbacks[media_signal]()
+    callbacks[media_signal]()
+    assert [entity.entity_description.key for entity in batches[1]] == ["cdrom_mode"]
+
+    coordinator.device_info.ips = [
+        SimpleNamespace(addr="192.0.2.10", type="wired", version="IPv4", name="eth0")
+    ]
+    callbacks[network_signal]("wired")
+    callbacks[network_signal]("wired")
+    assert [entity.entity_description.key for entity in batches[2]] == [
+        "wired_connected"
+    ]
+    assert len(batches) == 3
+
+
+@pytest.mark.asyncio
+async def test_binary_sensor_setup_handles_media_already_mounted(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mounted media present during setup must create its entity immediately."""
+    coordinator = _coordinator(
+        mounted_image=SimpleNamespace(file="/data/image.iso"),
+        supports_cdrom_endpoint=True,
+    )
+    _configure_hass(hass_mock, config_entry_mock, coordinator)
+    add_entities, batches = _entity_collector()
+    _capture_dispatchers(monkeypatch, binary_sensor_module)
+
+    await binary_sensor_module.async_setup_entry(
+        hass_mock, config_entry_mock, add_entities
+    )
+
+    assert [entity.entity_description.key for entity in batches[1]] == ["cdrom_mode"]
+
+
+@pytest.mark.asyncio
+async def test_sensor_setup_adds_dynamic_network_media_and_ssh_entities_once(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sensor setup must deduplicate each dynamically signaled entity group."""
+    coordinator = _coordinator()
+    _configure_hass(hass_mock, config_entry_mock, coordinator)
+    add_entities, batches = _entity_collector()
+    callbacks = _capture_dispatchers(monkeypatch, sensor_module)
+
+    await sensor_module.async_setup_entry(hass_mock, config_entry_mock, add_entities)
+
+    assert [entity.entity_description.key for entity in batches[0]] == [
+        "ip_address",
+        "tailscale_state",
+    ]
+    media_signal = SIGNAL_NEW_MEDIA_ENTITIES.format(config_entry_mock.entry_id)
+    network_signal = SIGNAL_NEW_NETWORK_ENTITIES.format(config_entry_mock.entry_id)
+    ssh_signal = SIGNAL_NEW_SSH_SENSORS.format(config_entry_mock.entry_id)
+    assert set(callbacks) == {media_signal, network_signal, ssh_signal}
+    assert config_entry_mock.async_on_unload.call_count == 3
+
+    callbacks[network_signal]("wired")
+    callbacks[media_signal]()
+    assert len(batches) == 1
+
+    coordinator.device_info.ips = [
+        SimpleNamespace(addr="192.0.2.10", type="wired", version="IPv4", name="eth0")
+    ]
+    callbacks[network_signal]("wired")
+    callbacks[network_signal]("wired")
+    assert [entity.entity_description.key for entity in batches[1]] == [
+        "wired_ip_address"
+    ]
+
+    coordinator.mounted_image = SimpleNamespace(file="/data/image.iso")
+    callbacks[media_signal]()
+    callbacks[media_signal]()
+    assert [entity.entity_description.key for entity in batches[2]] == ["mounted_image"]
+
+    callbacks[ssh_signal]()
+    callbacks[ssh_signal]()
+    assert [entity.entity_description.key for entity in batches[3]] == [
+        "uptime",
+        "cpu_temperature",
+        "memory_used_percent",
+        "storage_used_percent",
+    ]
+    assert coordinator.ssh_sensors_created is True
+    assert len(batches) == 4
+
+
+@pytest.mark.asyncio
+async def test_sensor_setup_handles_initial_media_and_ssh_state(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Initial mounted media and enabled SSH must create dynamic entities at setup."""
+    coordinator = _coordinator(
+        mounted_image=SimpleNamespace(file="/data/image.iso"),
+        ssh_state=SimpleNamespace(enabled=True),
+    )
+    _configure_hass(hass_mock, config_entry_mock, coordinator)
+    add_entities, batches = _entity_collector()
+    _capture_dispatchers(monkeypatch, sensor_module)
+
+    await sensor_module.async_setup_entry(hass_mock, config_entry_mock, add_entities)
+
+    assert [
+        [entity.entity_description.key for entity in batch] for batch in batches[1:]
+    ] == [
+        ["mounted_image"],
+        ["uptime", "cpu_temperature", "memory_used_percent", "storage_used_percent"],
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("hardware_info", "is_pro_hardware", "expected_keys"),
+    [
+        (None, False, ["power", "reset", "reboot", "reset_hid"]),
+        (
+            SimpleNamespace(version=HWVersion.PCIE),
+            True,
+            ["power", "reset", "reboot", "reset_hdmi", "reset_hid", "sync_time"],
+        ),
+    ],
+)
+async def test_button_setup_filters_entities_by_hardware(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    hardware_info: object,
+    is_pro_hardware: bool,
+    expected_keys: list[str],
+) -> None:
+    """Button setup must expose only actions supported by detected hardware."""
+    coordinator = _coordinator(
+        hardware_info=hardware_info,
+        is_pro_hardware=is_pro_hardware,
+    )
+    _configure_hass(hass_mock, config_entry_mock, coordinator)
+    add_entities, batches = _entity_collector()
+
+    await button_module.async_setup_entry(hass_mock, config_entry_mock, add_entities)
+
+    assert [entity.entity_description.key for entity in batches[0]] == expected_keys
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("has_led", [False, True])
+async def test_number_setup_filters_on_led_capability(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    has_led: bool,
+) -> None:
+    """LED numbers must be created only when Pro LED state is available."""
+    led_state = (
+        SimpleNamespace(on=True, brightness=50, horizontal_count=30, vertical_count=20)
+        if has_led
+        else None
+    )
+    coordinator = _coordinator(is_pro_hardware=has_led, led_strip=led_state)
+    _configure_hass(hass_mock, config_entry_mock, coordinator)
+    add_entities, batches = _entity_collector()
+
+    await number_module.async_setup_entry(hass_mock, config_entry_mock, add_entities)
+
+    assert [entity.entity_description.key for entity in batches[0]] == (
+        ["led_brightness", "led_horizontal_beads", "led_vertical_beads"]
+        if has_led
+        else []
+    )
+
+
+@pytest.mark.asyncio
+async def test_select_setup_filters_on_available_state(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+) -> None:
+    """Select setup must expose each control whose backing state is available."""
+    coordinator = _coordinator(
+        hid_mode=SimpleNamespace(mode=object()),
+        is_pro_hardware=True,
+        lcd_time_format=SimpleNamespace(format=object()),
+        mouse_jiggler_state=SimpleNamespace(enabled=False),
+        oled_info=SimpleNamespace(exist=True, sleep=0),
+        swap_size=0,
+        virtual_device_info=SimpleNamespace(
+            is_emmc_exist=True,
+            is_sd_card_exist=True,
+            mounted_disk="emmc",
+        ),
+    )
+    _configure_hass(hass_mock, config_entry_mock, coordinator)
+    add_entities, batches = _entity_collector()
+
+    await select_module.async_setup_entry(hass_mock, config_entry_mock, add_entities)
+
+    assert [entity.entity_description.key for entity in batches[0]] == [
+        "hid_mode",
+        "mouse_jiggler_mode",
+        "oled_sleep_timeout",
+        "swap_size",
+        "lcd_time_format",
+        "virtual_disk_type",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_switch_setup_uses_specialized_entities_and_dynamic_watchdog(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Switch setup must select specialized entity classes and add watchdog once."""
+    coordinator = _coordinator(
+        supports_non_pro_virtual_device_controls=True,
+        virtual_device_info=SimpleNamespace(network=False, disk=False, mic=None),
+    )
+    _configure_hass(hass_mock, config_entry_mock, coordinator)
+    add_entities, batches = _entity_collector()
+    callbacks = _capture_dispatchers(monkeypatch, switch_module)
+
+    await switch_module.async_setup_entry(hass_mock, config_entry_mock, add_entities)
+
+    assert [entity.entity_description.key for entity in batches[0]] == [
+        "ssh",
+        "mdns",
+        "virtual_network",
+        "virtual_disk",
+        "power",
+    ]
+    assert isinstance(batches[0][2], switch_module.NanoKVMVirtualDeviceSwitch)
+    assert isinstance(batches[0][3], switch_module.NanoKVMVirtualDeviceSwitch)
+    assert isinstance(batches[0][4], switch_module.NanoKVMPowerSwitch)
+
+    signal = SIGNAL_NEW_SSH_SWITCHES.format(config_entry_mock.entry_id)
+    assert set(callbacks) == {signal}
+    callbacks[signal]()
+    assert len(batches) == 1
+
+    coordinator.supports_watchdog = True
+    coordinator.watchdog_enabled = False
+    callbacks[signal]()
+    callbacks[signal]()
+    assert [entity.entity_description.key for entity in batches[1]] == ["watchdog"]
+    assert isinstance(batches[1][0], switch_module.NanoKVMWatchdogSwitch)
+    assert coordinator.ssh_switches_created is True
+    assert len(batches) == 2
+
+
+@pytest.mark.asyncio
+async def test_switch_setup_handles_initial_watchdog_state(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An already available watchdog must be registered during setup."""
+    coordinator = _coordinator(supports_watchdog=True, watchdog_enabled=True)
+    _configure_hass(hass_mock, config_entry_mock, coordinator)
+    add_entities, batches = _entity_collector()
+    _capture_dispatchers(monkeypatch, switch_module)
+
+    await switch_module.async_setup_entry(hass_mock, config_entry_mock, add_entities)
+
+    assert [entity.entity_description.key for entity in batches[1]] == ["watchdog"]
+
+
+@pytest.mark.asyncio
+async def test_update_setup_adds_application_update(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+) -> None:
+    """Update setup must expose the application firmware updater."""
+    coordinator = _coordinator()
+    _configure_hass(hass_mock, config_entry_mock, coordinator)
+    add_entities, batches = _entity_collector()
+
+    await update_module.async_setup_entry(hass_mock, config_entry_mock, add_entities)
+
+    assert [entity.entity_description.key for entity in batches[0]] == ["application"]


### PR DESCRIPTION
## Summary

- add async pytest support and shared Home Assistant/config-entry fixtures
- cover integration setup, unload, platform forwarding, service registration, and cleanup
- cover coordinator polling, optional endpoints, failover, reauthentication, capabilities, dispatchers, SSH coordination, and shutdown
- cover user, authentication, reauthentication, SSL fingerprint, and zeroconf config-flow paths
- cover all service schemas, target resolution, handlers, responses, errors, and unregister behavior
- cover platform setup, dynamic entity registration, entity actions, and error translation

## Why

The first coverage PR established the suite structure around pure helpers and stable value contracts. This second stage exercises the Home Assistant lifecycle and API orchestration boundaries while keeping camera/WebRTC and the standalone SSH collector isolated for the next focused PR.

## Impact

The suite now contains 504 tests and total line coverage increases from 45% to 76% without changing integration runtime behavior. Services and all non-media entity platforms reach complete line coverage, integration setup and config flow reach 99%, and the coordinator reaches 97%.