### PR TITLE
test: cover camera and SSH lifecycle

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,4 +3,5 @@ homeassistant==2026.5.1
 nanokvm==1.2.0
 pytest>=9.0,<10.0
 pytest-asyncio>=1.4,<2.0
+PyTurboJPEG==1.8.3
 ruff>=0.15,<1.0

--- a/tests/platforms/test_camera.py
+++ b/tests/platforms/test_camera.py
@@ -1,0 +1,447 @@
+"""Tests for the NanoKVM camera platform."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+import logging
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.components.camera import CameraEntityFeature, CameraState
+from homeassistant.components.camera.const import StreamType
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+import pytest
+from webrtc_models import RTCIceCandidateInit
+from yarl import URL
+
+import custom_components.nanokvm.camera as camera_module
+from custom_components.nanokvm.const import CONF_SSL_FINGERPRINT, DOMAIN
+
+
+def _coordinator(**overrides: object) -> SimpleNamespace:
+    """Build the coordinator state consumed by the camera entity."""
+    values: dict[str, object] = {
+        "client": SimpleNamespace(
+            url=URL("http://nanokvm.local/api/"),
+            token="existing-token",
+        ),
+        "config_entry": SimpleNamespace(
+            data={CONF_USERNAME: "admin", CONF_PASSWORD: "password"}
+        ),
+        "device_info": SimpleNamespace(device_key="test-device"),
+        "is_pro_hardware": False,
+        "last_update_success": True,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _camera(
+    monkeypatch: pytest.MonkeyPatch,
+    coordinator: SimpleNamespace | None = None,
+) -> tuple[
+    camera_module.NanoKVMCamera,
+    MagicMock,
+    MagicMock,
+]:
+    """Create a camera with its WebRTC manager isolated at the platform edge."""
+    manager = MagicMock()
+    manager.async_handle_async_webrtc_offer = AsyncMock()
+    manager.async_on_webrtc_candidate = AsyncMock()
+    manager.async_shutdown = AsyncMock()
+    manager_factory = MagicMock(return_value=manager)
+    monkeypatch.setattr(camera_module, "NanoKVMWebRTCManager", manager_factory)
+
+    entity = camera_module.NanoKVMCamera(
+        coordinator or _coordinator(), camera_module.CAMERAS[0]
+    )
+    return entity, manager, manager_factory
+
+
+def test_camera_description_inventory_and_default_availability() -> None:
+    """The platform exposes one always-created HDMI stream description."""
+    assert [description.key for description in camera_module.CAMERAS] == ["hdmi"]
+    assert camera_module.CAMERAS[0].available_fn(_coordinator()) is True
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_filters_unavailable_descriptions(
+    hass_mock: MagicMock,
+    config_entry_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setup eagerly adds only descriptions whose capability predicate passes."""
+    coordinator = _coordinator()
+    hass_mock.data = {DOMAIN: {config_entry_mock.entry_id: coordinator}}
+    descriptions = (
+        camera_module.NanoKVMCameraEntityDescription(
+            key="available", available_fn=lambda _: True
+        ),
+        camera_module.NanoKVMCameraEntityDescription(
+            key="unavailable", available_fn=lambda _: False
+        ),
+    )
+    monkeypatch.setattr(camera_module, "CAMERAS", descriptions)
+    entity_factory = MagicMock(side_effect=lambda **kwargs: kwargs["description"].key)
+    monkeypatch.setattr(camera_module, "NanoKVMCamera", entity_factory)
+    batches: list[list[object]] = []
+
+    await camera_module.async_setup_entry(
+        hass_mock,
+        config_entry_mock,
+        lambda entities: batches.append(list(entities)),
+    )
+
+    assert batches == [["available"]]
+    entity_factory.assert_called_once_with(
+        coordinator=coordinator,
+        description=descriptions[0],
+    )
+
+
+@pytest.mark.asyncio
+async def test_camera_initializes_native_webrtc_stream(
+    hass_mock: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Entity metadata and manager providers describe a native WebRTC camera."""
+    coordinator = _coordinator(is_pro_hardware=True)
+    entity, _manager, manager_factory = _camera(monkeypatch, coordinator)
+    entity.hass = hass_mock
+
+    assert entity.unique_id == "test-device_camera_hdmi"
+    assert entity.supported_features == CameraEntityFeature.STREAM
+    assert entity.is_streaming is True
+    assert entity.state == CameraState.STREAMING
+    assert entity.available is True
+    coordinator.last_update_success = False
+    assert entity.available is False
+    assert await entity.stream_source() is None
+    assert entity.camera_capabilities.frontend_stream_types == {StreamType.WEB_RTC}
+
+    manager_factory.assert_called_once()
+    manager_options = manager_factory.call_args.kwargs
+    assert manager_options["logger"] is camera_module._LOGGER
+    assert manager_options["hass_provider"]() is hass_mock
+    assert manager_options["client_factory"] == entity._create_stream_client
+    assert manager_options["authenticate_client"] == entity._authenticate_stream_client
+    assert manager_options["is_pro_hardware"]() is True
+    assert manager_options["login_timeout_seconds"] == 15
+    assert manager_options["websocket_heartbeat_seconds"] == 30.0
+    assert manager_options["max_pending_ice_candidates"] == 64
+
+
+@pytest.mark.parametrize(
+    ("config_entry", "expected"),
+    [
+        (None, None),
+        (SimpleNamespace(data={}), None),
+        (SimpleNamespace(data={CONF_PASSWORD: "password"}), None),
+        (SimpleNamespace(data={CONF_USERNAME: "admin"}), None),
+        (
+            SimpleNamespace(data={CONF_USERNAME: "admin", CONF_PASSWORD: "password"}),
+            ("admin", "password"),
+        ),
+    ],
+)
+def test_stream_credentials_require_complete_config(
+    monkeypatch: pytest.MonkeyPatch,
+    config_entry: SimpleNamespace | None,
+    expected: tuple[str, str] | None,
+) -> None:
+    """Stream credentials are usable only when both values are configured."""
+    entity, _manager, _manager_factory = _camera(
+        monkeypatch, _coordinator(config_entry=config_entry)
+    )
+
+    assert entity._stream_credentials() == expected
+
+
+@pytest.mark.parametrize("config_entry", [None, SimpleNamespace(data={})])
+def test_create_stream_client_requires_config_data(
+    monkeypatch: pytest.MonkeyPatch,
+    config_entry: SimpleNamespace | None,
+) -> None:
+    """No standalone stream client is created without entry data."""
+    entity, _manager, _manager_factory = _camera(
+        monkeypatch, _coordinator(config_entry=config_entry)
+    )
+    client_factory = MagicMock()
+    monkeypatch.setattr(camera_module, "NanoKVMClient", client_factory)
+
+    assert entity._create_stream_client() is None
+    client_factory.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_fingerprint"),
+    [
+        (URL("http://nanokvm.local/api/"), None),
+        (URL("https://nanokvm.local/api/"), "sha256:fingerprint"),
+    ],
+)
+def test_create_stream_client_reuses_active_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    url: URL,
+    expected_fingerprint: str | None,
+) -> None:
+    """Stream clients inherit the resolved URL, token, and HTTPS fingerprint."""
+    config_entry = SimpleNamespace(
+        data={
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "password",
+            CONF_SSL_FINGERPRINT: "sha256:fingerprint",
+        }
+    )
+    entity, _manager, _manager_factory = _camera(
+        monkeypatch,
+        _coordinator(
+            client=SimpleNamespace(url=url, token="existing-token"),
+            config_entry=config_entry,
+        ),
+    )
+    stream_client = object()
+    client_factory = MagicMock(return_value=stream_client)
+    monkeypatch.setattr(camera_module, "NanoKVMClient", client_factory)
+
+    assert entity._create_stream_client() is stream_client
+    client_factory.assert_called_once_with(
+        str(url),
+        token="existing-token",
+        ssl_fingerprint=expected_fingerprint,
+    )
+
+
+@pytest.mark.asyncio
+async def test_authenticate_stream_client_rejects_missing_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing credentials fail before an authentication request is attempted."""
+    entity, _manager, _manager_factory = _camera(
+        monkeypatch, _coordinator(config_entry=None)
+    )
+    client = SimpleNamespace(token=None, authenticate=AsyncMock())
+
+    with pytest.raises(RuntimeError, match="Missing NanoKVM stream credentials"):
+        await entity._authenticate_stream_client(client)
+
+    client.authenticate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("token", ["existing-token", None])
+async def test_authenticate_stream_client_uses_existing_or_configured_auth(
+    monkeypatch: pytest.MonkeyPatch,
+    token: str | None,
+) -> None:
+    """Existing tokens bypass login while empty clients authenticate once."""
+    entity, _manager, _manager_factory = _camera(monkeypatch)
+    client = SimpleNamespace(token=token, authenticate=AsyncMock())
+
+    await entity._authenticate_stream_client(client)
+
+    if token:
+        client.authenticate.assert_not_awaited()
+    else:
+        client.authenticate.assert_awaited_once_with("admin", "password")
+
+
+@pytest.mark.asyncio
+async def test_snapshot_is_suppressed_on_pro_hardware(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Pro snapshot never opens MJPEG because it would interrupt WebRTC."""
+    entity, _manager, _manager_factory = _camera(
+        monkeypatch, _coordinator(is_pro_hardware=True)
+    )
+    create_client = MagicMock()
+    monkeypatch.setattr(entity, "_create_stream_client", create_client)
+
+    assert await entity._async_read_snapshot_frame() is None
+    create_client.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_returns_none_when_client_cannot_be_created(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Snapshot reads stop cleanly when the config cannot build a client."""
+    entity, _manager, _manager_factory = _camera(monkeypatch)
+    monkeypatch.setattr(entity, "_create_stream_client", MagicMock(return_value=None))
+
+    assert await entity._async_read_snapshot_frame() is None
+
+
+class _RequestContext(AbstractAsyncContextManager[object]):
+    """Async request context used by snapshot reader tests."""
+
+    def __init__(self, upstream: object) -> None:
+        self.upstream = upstream
+        self.exited = False
+
+    async def __aenter__(self) -> object:
+        return self.upstream
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        self.exited = True
+
+
+class _StreamClient(AbstractAsyncContextManager["_StreamClient"]):
+    """Authenticated-client test double retaining request observations."""
+
+    def __init__(self, upstream: object) -> None:
+        self.request_context = _RequestContext(upstream)
+        self.requests: list[tuple[str, str]] = []
+        self.exited = False
+
+    async def __aenter__(self) -> _StreamClient:
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        self.exited = True
+
+    def _request(self, method: str, path: str) -> _RequestContext:
+        self.requests.append((method, path))
+        return self.request_context
+
+
+class _Reader:
+    """Multipart reader returning a prescribed sequence of parts."""
+
+    def __init__(self, parts: list[object | None]) -> None:
+        self.parts = iter(parts)
+
+    async def next(self) -> object | None:
+        return next(self.parts)
+
+
+class _BodyPart:
+    """Body part returning one prescribed payload."""
+
+    def __init__(self, payload: bytes) -> None:
+        self.read = AsyncMock(return_value=payload)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("parts", "expected"),
+    [
+        ([None], None),
+        ([object(), _BodyPart(b"jpeg")], b"jpeg"),
+        ([_BodyPart(b""), None], None),
+    ],
+)
+async def test_snapshot_scans_multipart_response_for_nonempty_frame(
+    monkeypatch: pytest.MonkeyPatch,
+    parts: list[object | None],
+    expected: bytes | None,
+) -> None:
+    """Multipart metadata and empty frames are skipped until JPEG data or EOF."""
+    entity, _manager, _manager_factory = _camera(monkeypatch)
+    upstream = object()
+    client = _StreamClient(upstream)
+    authenticate = AsyncMock()
+    reader = _Reader(parts)
+    monkeypatch.setattr(entity, "_create_stream_client", MagicMock(return_value=client))
+    monkeypatch.setattr(entity, "_authenticate_stream_client", authenticate)
+    monkeypatch.setattr(camera_module, "BodyPartReader", _BodyPart)
+    from_response = MagicMock(return_value=reader)
+    monkeypatch.setattr(camera_module.MultipartReader, "from_response", from_response)
+
+    assert await entity._async_read_snapshot_frame() == expected
+    assert client.requests == [("GET", "/stream/mjpeg")]
+    assert client.exited is True
+    assert client.request_context.exited is True
+    authenticate.assert_awaited_once_with(client)
+    from_response.assert_called_once_with(upstream)
+
+
+@pytest.mark.asyncio
+async def test_async_camera_image_returns_frame_and_handles_fetch_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Still-image requests return bytes, but ordinary fetch errors become no image."""
+    entity, _manager, _manager_factory = _camera(monkeypatch)
+    read_frame = AsyncMock(return_value=b"jpeg")
+    monkeypatch.setattr(entity, "_async_read_snapshot_frame", read_frame)
+
+    assert await entity.async_camera_image(width=640, height=480) == b"jpeg"
+
+    read_frame.side_effect = TimeoutError("snapshot timed out")
+    with caplog.at_level(logging.ERROR, logger=camera_module.__name__):
+        assert await entity.async_camera_image() is None
+
+    assert "Error fetching still image: snapshot timed out" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_async_camera_image_propagates_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Task cancellation is not converted into an ordinary missing snapshot."""
+    entity, _manager, _manager_factory = _camera(monkeypatch)
+    monkeypatch.setattr(
+        entity,
+        "_async_read_snapshot_frame",
+        AsyncMock(side_effect=asyncio.CancelledError),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await entity.async_camera_image()
+
+
+@pytest.mark.asyncio
+async def test_webrtc_calls_delegate_to_manager(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Offers, ICE candidates, and close notifications retain their arguments."""
+    entity, manager, _manager_factory = _camera(monkeypatch)
+    send_message: Callable[[Any], None] = MagicMock()
+    candidate = RTCIceCandidateInit(
+        candidate="candidate:1",
+        sdp_mid="0",
+        sdp_m_line_index=0,
+        user_fragment=None,
+    )
+
+    await entity.async_handle_async_webrtc_offer(
+        "offer-sdp", "offer-session", send_message
+    )
+    await entity.async_on_webrtc_candidate("candidate-session", candidate)
+    entity.close_webrtc_session("closed-session")
+
+    manager.async_handle_async_webrtc_offer.assert_awaited_once_with(
+        "offer-sdp", "offer-session", send_message
+    )
+    manager.async_on_webrtc_candidate.assert_awaited_once_with(
+        "candidate-session", candidate
+    )
+    manager.close_webrtc_session.assert_called_once_with("closed-session")
+
+
+@pytest.mark.asyncio
+async def test_camera_removal_runs_entity_and_webrtc_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Removal executes inherited entity cleanup before manager shutdown."""
+    calls: list[str] = []
+
+    async def super_cleanup(_entity: object) -> None:
+        calls.append("entity")
+
+    entity, manager, _manager_factory = _camera(monkeypatch)
+    manager.async_shutdown.side_effect = lambda: calls.append("webrtc")
+    monkeypatch.setattr(
+        camera_module.NanoKVMEntity,
+        "async_will_remove_from_hass",
+        super_cleanup,
+    )
+
+    await entity.async_will_remove_from_hass()
+
+    assert calls == ["entity", "webrtc"]
+    manager.async_shutdown.assert_awaited_once_with()

--- a/tests/unit/test_camera_webrtc.py
+++ b/tests/unit/test_camera_webrtc.py
@@ -1,0 +1,933 @@
+"""Behavior tests for NanoKVM WebRTC signaling and session lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from collections.abc import Callable, Coroutine
+import json
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+from aiohttp import WSMsgType
+from homeassistant.components.camera.webrtc import (
+    WebRTCAnswer,
+    WebRTCCandidate,
+    WebRTCError,
+)
+from homeassistant.exceptions import HomeAssistantError
+import pytest
+import pytest_asyncio
+from webrtc_models import RTCIceCandidateInit
+from yarl import URL
+
+from custom_components.nanokvm import camera_webrtc as webrtc_module
+from custom_components.nanokvm.camera_webrtc import NanoKVMWebRTCManager
+
+
+COMBINED_OFFER = "\r\n".join(
+    (
+        "v=0",
+        "o=- 1 1 IN IP4 127.0.0.1",
+        "s=-",
+        "t=0 0",
+        "a=group:BUNDLE video-main audio-main",
+        "m=video 9 UDP/TLS/RTP/SAVPF 96",
+        "a=mid:video-main",
+        "a=sendrecv",
+        "m=audio 9 UDP/TLS/RTP/SAVPF 111",
+        "a=mid:audio-main",
+        "a=sendrecv",
+        "",
+    )
+)
+VIDEO_ONLY_OFFER = "\r\n".join(
+    (
+        "v=0",
+        "o=- 1 1 IN IP4 127.0.0.1",
+        "s=-",
+        "t=0 0",
+        "a=group:BUNDLE camera",
+        "m=video 9 UDP/TLS/RTP/SAVPF 96",
+        "a=mid:camera",
+        "a=sendrecv",
+        "",
+    )
+)
+VIDEO_ANSWER = "\r\n".join(
+    (
+        "v=0",
+        "o=- 2 2 IN IP4 127.0.0.1",
+        "s=-",
+        "t=0 0",
+        "a=ice-ufrag:video-ufrag",
+        "a=ice-pwd:video-password",
+        "m=video 9 UDP/TLS/RTP/SAVPF 96",
+        "a=mid:0",
+        "a=recvonly",
+        "",
+    )
+)
+AUDIO_ANSWER = "\r\n".join(
+    (
+        "v=0",
+        "o=- 3 3 IN IP4 127.0.0.1",
+        "s=-",
+        "t=0 0",
+        "a=ice-ufrag:audio-ufrag",
+        "a=ice-pwd:audio-password",
+        "m=audio 9 UDP/TLS/RTP/SAVPF 111",
+        "a=mid:0",
+        "a=recvonly",
+        "",
+    )
+)
+_END = object()
+
+
+class FakeWebSocket:
+    """Small asynchronous WebSocket boundary with observable I/O."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict[str, object]] = []
+        self.closed = False
+        self.close_code: int | None = None
+        self.close_calls = 0
+        self.send_failures: dict[str, Exception] = {}
+        self.close_error: Exception | None = None
+        self._incoming: asyncio.Queue[object] = asyncio.Queue()
+        self._exception: Exception | None = None
+
+    def __aiter__(self) -> FakeWebSocket:
+        return self
+
+    async def __anext__(self) -> object:
+        item = await self._incoming.get()
+        if item is _END:
+            raise StopAsyncIteration
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    async def send_json(self, payload: dict[str, object]) -> None:
+        event = payload.get("event")
+        if isinstance(event, str) and event in self.send_failures:
+            raise self.send_failures[event]
+        self.sent.append(payload)
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        self.closed = True
+        self._incoming.put_nowait(_END)
+        if self.close_error is not None:
+            raise self.close_error
+
+    def exception(self) -> Exception | None:
+        """Return the transport exception exposed by aiohttp."""
+        return self._exception
+
+    def feed_signal(self, event: object, data: object = "") -> None:
+        """Feed one JSON signaling message to the reader."""
+        self.feed_raw(json.dumps({"event": event, "data": data}))
+
+    def feed_raw(
+        self, data: object, *, message_type: WSMsgType = WSMsgType.TEXT
+    ) -> None:
+        """Feed one aiohttp-shaped message to the reader."""
+        self._incoming.put_nowait(SimpleNamespace(type=message_type, data=data))
+
+    def feed_error(self, error: Exception) -> None:
+        """Make the reader's next receive raise an exception."""
+        self._exception = error
+        self._incoming.put_nowait(error)
+
+    def feed_close(self) -> None:
+        """Feed the close frame observed by a normal reader shutdown."""
+        self._incoming.put_nowait(SimpleNamespace(type=WSMsgType.CLOSE, data=None))
+
+
+class FakeTransport:
+    """NanoKVM client's aiohttp session boundary."""
+
+    def __init__(self, websocket: FakeWebSocket) -> None:
+        self.websocket = websocket
+        self.calls: list[tuple[str, dict[str, object]]] = []
+        self.error: Exception | None = None
+        self.connect_started = asyncio.Event()
+        self.connect_release: asyncio.Event | None = None
+
+    async def ws_connect(self, url: str, **kwargs: object) -> FakeWebSocket:
+        """Record the WebSocket request and return or fail the connection."""
+        self.calls.append((url, kwargs))
+        self.connect_started.set()
+        if self.connect_release is not None:
+            await self.connect_release.wait()
+        if self.error is not None:
+            raise self.error
+        return self.websocket
+
+
+class FakeClient:
+    """Authenticated NanoKVM streaming-client boundary."""
+
+    def __init__(
+        self,
+        websocket: FakeWebSocket | None = None,
+        *,
+        url: str = "http://nanokvm.local/api",
+    ) -> None:
+        self.url = URL(url)
+        self.token: str | None = "stream-token"
+        self.websocket = websocket or FakeWebSocket()
+        self.transport = FakeTransport(self.websocket)
+        self._session: FakeTransport | None = self.transport
+        self._ssl_config: object | None = object()
+        self.enter_calls = 0
+        self.exit_calls = 0
+        self.exit_error: Exception | None = None
+
+    async def __aenter__(self) -> FakeClient:
+        self.enter_calls += 1
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: object,
+    ) -> None:
+        self.exit_calls += 1
+        if self.exit_error is not None:
+            raise self.exit_error
+
+
+class FakeHass:
+    """Home Assistant task-scheduling boundary."""
+
+    def __init__(self) -> None:
+        self.tasks: list[asyncio.Task[None]] = []
+
+    def async_create_task(self, coro: Coroutine[Any, Any, None]) -> asyncio.Task[None]:
+        """Schedule and retain an integration task."""
+        task = asyncio.create_task(coro)
+        self.tasks.append(task)
+        return task
+
+
+class WebRTCHarness:
+    """Manager with controllable external boundaries."""
+
+    def __init__(
+        self,
+        *,
+        clients: list[FakeClient | None] | None = None,
+        hass: FakeHass | None = None,
+        hass_ready: bool = True,
+        pro: bool = False,
+        authenticate_error: Exception | None = None,
+        signaling_heartbeat_seconds: float = 60.0,
+        max_pending_ice_candidates: int = 64,
+    ) -> None:
+        self.clients = deque(clients or [FakeClient()])
+        self.hass = hass or FakeHass()
+        self.hass_ready = hass_ready
+        self.authenticate_error = authenticate_error
+        self.authenticated: list[FakeClient] = []
+
+        async def authenticate(client: FakeClient) -> None:
+            self.authenticated.append(client)
+            if self.authenticate_error is not None:
+                raise self.authenticate_error
+
+        self.manager = NanoKVMWebRTCManager(
+            logger=logging.getLogger(__name__),
+            hass_provider=lambda: self.hass if self.hass_ready else None,
+            client_factory=lambda: self.clients.popleft(),
+            authenticate_client=authenticate,
+            is_pro_hardware=lambda: pro,
+            signaling_heartbeat_seconds=signaling_heartbeat_seconds,
+            max_pending_ice_candidates=max_pending_ice_candidates,
+        )
+
+
+@pytest_asyncio.fixture
+async def harness_factory() -> Any:
+    """Build harnesses and guarantee active signaling tasks are collected."""
+    harnesses: list[WebRTCHarness] = []
+
+    def factory(**kwargs: object) -> WebRTCHarness:
+        harness = WebRTCHarness(**kwargs)
+        harnesses.append(harness)
+        return harness
+
+    yield factory
+
+    for harness in harnesses:
+        await harness.manager.async_shutdown()
+        if harness.hass.tasks:
+            await asyncio.gather(*harness.hass.tasks, return_exceptions=True)
+
+
+def _candidate(
+    value: str = "candidate:1 1 UDP 1 192.0.2.10 5000 typ host",
+    *,
+    mid: str | None = "video-main",
+    index: int | None = 0,
+    user_fragment: str | None = "ufrag",
+) -> RTCIceCandidateInit:
+    """Return a representative frontend or device ICE candidate."""
+    return RTCIceCandidateInit(
+        value,
+        sdp_mid=mid,
+        sdp_m_line_index=index,
+        user_fragment=user_fragment,
+    )
+
+
+def _decode_sent_data(message: dict[str, object]) -> dict[str, object]:
+    """Decode one outbound NanoKVM signaling data field."""
+    data = message["data"]
+    assert isinstance(data, str)
+    decoded = json.loads(data)
+    assert isinstance(decoded, dict)
+    return decoded
+
+
+async def _finish_reader(client: FakeClient, hass: FakeHass) -> None:
+    """End a reader through the normal WebSocket close-frame path."""
+    client.websocket.feed_close()
+    await hass.tasks[0]
+
+
+async def test_non_pro_session_signals_offer_answer_candidate_and_cleanup(
+    harness_factory: Callable[..., WebRTCHarness],
+) -> None:
+    """A complete non-Pro exchange must preserve SDP, ICE, and transport state."""
+    client = FakeClient(url="https://nanokvm.local/api")
+    harness = harness_factory(clients=[client])
+    messages: list[object] = []
+
+    await harness.manager.async_handle_async_webrtc_offer(
+        VIDEO_ONLY_OFFER, "session", messages.append
+    )
+
+    assert client.enter_calls == 1
+    assert harness.authenticated == [client]
+    assert len(client.transport.calls) == 1
+    url, kwargs = client.transport.calls[0]
+    assert url == "wss://nanokvm.local/api/stream/h264"
+    assert kwargs["headers"] == {"Cookie": "nano-kvm-token=stream-token"}
+    assert kwargs["heartbeat"] == 30.0
+    assert kwargs["ssl"] is client._ssl_config
+    timeout = kwargs["timeout"]
+    assert isinstance(timeout, webrtc_module.aiohttp.ClientWSTimeout)
+    assert timeout.ws_close == 15
+    assert timeout.ws_receive is None
+    assert client.websocket.sent == [
+        {
+            "event": "video-offer",
+            "data": json.dumps({"type": "offer", "sdp": VIDEO_ONLY_OFFER}),
+        }
+    ]
+
+    client.websocket.feed_signal(
+        "video-answer", json.dumps({"type": "answer", "sdp": VIDEO_ANSWER})
+    )
+    client.websocket.feed_signal(
+        "video-candidate",
+        json.dumps(
+            {
+                "candidate": "candidate:device",
+                "sdpMid": "0",
+                "sdpMLineIndex": 0,
+                "usernameFragment": "device-ufrag",
+            }
+        ),
+    )
+    await _finish_reader(client, harness.hass)
+
+    assert messages == [
+        WebRTCAnswer(answer=VIDEO_ANSWER),
+        WebRTCCandidate(
+            candidate=RTCIceCandidateInit(
+                "candidate:device",
+                sdp_mid="0",
+                sdp_m_line_index=0,
+                user_fragment="device-ufrag",
+            )
+        ),
+    ]
+    assert client.websocket.closed
+    assert client.exit_calls == 1
+
+
+async def test_reader_ignores_malformed_irrelevant_and_non_text_messages(
+    harness_factory: Callable[..., WebRTCHarness],
+) -> None:
+    """Noise on the signaling socket must not surface false HA messages."""
+    client = FakeClient()
+    harness = harness_factory(clients=[client])
+    messages: list[object] = []
+    await harness.manager.async_handle_async_webrtc_offer(
+        VIDEO_ONLY_OFFER, "session", messages.append
+    )
+
+    client.websocket.feed_raw("not json")
+    client.websocket.feed_raw(json.dumps(["not", "an", "envelope"]))
+    client.websocket.feed_raw(json.dumps({"data": "{}"}))
+    client.websocket.feed_signal("heartbeat")
+    client.websocket.feed_signal("video-answer", "not json")
+    client.websocket.feed_signal("video-answer", json.dumps(["not", "a", "mapping"]))
+    client.websocket.feed_signal("video-answer", {})
+    client.websocket.feed_signal("unknown", {"value": 1})
+    client.websocket.feed_raw(b"ignored", message_type=WSMsgType.BINARY)
+    await _finish_reader(client, harness.hass)
+
+    assert messages == []
+    assert client.exit_calls == 1
+
+
+async def test_pro_session_splits_offer_and_merges_answers_and_candidates(
+    harness_factory: Callable[..., WebRTCHarness],
+) -> None:
+    """Pro split peers must appear to HA as one combined peer connection."""
+    client = FakeClient()
+    harness = harness_factory(clients=[client], pro=True)
+    messages: list[object] = []
+
+    await harness.manager.async_handle_async_webrtc_offer(
+        COMBINED_OFFER, "pro-session", messages.append
+    )
+
+    assert [message["event"] for message in client.websocket.sent] == [
+        "video-offer",
+        "audio-offer",
+    ]
+    assert client.transport.calls[0][0].endswith("/api/stream/h264/webrtc")
+    assert client.transport.calls[0][1]["heartbeat"] is None
+    client.websocket.feed_signal(
+        "video-candidate",
+        json.dumps(
+            {
+                "candidate": "candidate:video-before-answer",
+                "sdpMid": "0",
+                "sdpMLineIndex": 0,
+            }
+        ),
+    )
+    client.websocket.feed_signal("video-answer", json.dumps({"sdp": VIDEO_ANSWER}))
+    client.websocket.feed_signal("audio-answer", json.dumps({"sdp": AUDIO_ANSWER}))
+    client.websocket.feed_signal(
+        "audio-candidate",
+        json.dumps(
+            {
+                "candidate": "candidate:audio-after-answer",
+                "sdpMid": "0",
+                "sdpMLineIndex": 0,
+            }
+        ),
+    )
+    await _finish_reader(client, harness.hass)
+
+    assert isinstance(messages[0], WebRTCAnswer)
+    assert "a=mid:video-main\r\n" in messages[0].answer
+    assert "a=mid:audio-main\r\n" in messages[0].answer
+    assert messages[1:] == [
+        WebRTCCandidate(
+            candidate=RTCIceCandidateInit(
+                "candidate:video-before-answer",
+                sdp_mid="video-main",
+                sdp_m_line_index=0,
+            )
+        ),
+        WebRTCCandidate(
+            candidate=RTCIceCandidateInit(
+                "candidate:audio-after-answer",
+                sdp_mid="audio-main",
+                sdp_m_line_index=1,
+            )
+        ),
+    ]
+
+
+async def test_pro_video_only_offer_completes_with_one_answer(
+    harness_factory: Callable[..., WebRTCHarness],
+) -> None:
+    """Pro video-only offers must not wait for an audio answer that was not offered."""
+    client = FakeClient()
+    harness = harness_factory(clients=[client], pro=True)
+    messages: list[object] = []
+
+    await harness.manager.async_handle_async_webrtc_offer(
+        VIDEO_ONLY_OFFER, "pro-video", messages.append
+    )
+    client.websocket.feed_signal("video-status", {"status": 1})
+    client.websocket.feed_signal("audio-status", None)
+    client.websocket.feed_signal("audio-answer", None)
+    client.websocket.feed_signal("video-answer", {})
+    client.websocket.feed_signal("audio-candidate", None)
+    client.websocket.feed_signal("video-candidate", {})
+    client.websocket.feed_signal("unknown", {"value": 1})
+    client.websocket.feed_signal("audio-answer", json.dumps({"sdp": AUDIO_ANSWER}))
+    client.websocket.feed_signal("video-answer", json.dumps({"sdp": VIDEO_ANSWER}))
+    await _finish_reader(client, harness.hass)
+
+    assert [message["event"] for message in client.websocket.sent] == ["video-offer"]
+    assert len(messages) == 1
+    assert isinstance(messages[0], WebRTCAnswer)
+
+
+async def test_pro_inconsistent_video_status_reports_error_and_closes(
+    harness_factory: Callable[..., WebRTCHarness],
+) -> None:
+    """The device's conflicting-video-mode status must terminate the session."""
+    client = FakeClient()
+    harness = harness_factory(clients=[client], pro=True)
+    messages: list[object] = []
+    await harness.manager.async_handle_async_webrtc_offer(
+        VIDEO_ONLY_OFFER, "pro-session", messages.append
+    )
+
+    client.websocket.feed_signal("video-status", json.dumps({"status": "-4"}))
+    await harness.hass.tasks[0]
+
+    assert messages == [
+        WebRTCError(
+            code="webrtc_inconsistent_video_mode",
+            message=(
+                "NanoKVM Pro stopped WebRTC video because another video mode is active"
+            ),
+        )
+    ]
+    assert client.websocket.closed
+    assert client.exit_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("data", "raw_data", "expected"),
+    [
+        ({"code": 1.9}, None, 1),
+        ({"value": "-4"}, None, -4),
+        ({"status": "bad"}, -1.2, -1),
+        (None, '"1"', 1),
+        (None, "{}", None),
+        (None, None, None),
+        (None, "not-a-status", None),
+    ],
+)
+def test_pro_status_decoding_accepts_device_payload_variants(
+    harness_factory: Callable[..., WebRTCHarness],
+    data: dict[str, object] | None,
+    raw_data: object,
+    expected: int | None,
+) -> None:
+    """Known Pro firmware status shapes must normalize to numeric codes."""
+    manager = harness_factory().manager
+
+    assert manager._status_code_from_signal_data(data, raw_data) == expected
+
+
+async def test_candidate_concurrent_with_connection_is_queued_capped_and_flushed(
+    harness_factory: Callable[..., WebRTCHarness],
+) -> None:
+    """ICE arriving during setup must flush after the offer without exceeding the cap."""
+    client = FakeClient()
+    client.transport.connect_release = asyncio.Event()
+    harness = harness_factory(clients=[client], max_pending_ice_candidates=2)
+    offer_task = asyncio.create_task(
+        harness.manager.async_handle_async_webrtc_offer(
+            VIDEO_ONLY_OFFER, "session", lambda message: None
+        )
+    )
+    try:
+        await client.transport.connect_started.wait()
+
+        candidates = [_candidate(f"candidate:{index}") for index in range(3)]
+        await asyncio.gather(
+            *(
+                harness.manager.async_on_webrtc_candidate("session", item)
+                for item in candidates
+            )
+        )
+        client.transport.connect_release.set()
+        await offer_task
+    finally:
+        client.transport.connect_release.set()
+        if not offer_task.done():
+            offer_task.cancel()
+            await asyncio.gather(offer_task, return_exceptions=True)
+
+    assert [message["event"] for message in client.websocket.sent] == [
+        "video-offer",
+        "video-candidate",
+        "video-candidate",
+    ]
+    assert [
+        _decode_sent_data(message)["candidate"] for message in client.websocket.sent[1:]
+    ] == ["candidate:0", "candidate:1"]
+
+
+async def test_frontend_candidates_route_to_non_pro_and_pro_media(
+    harness_factory: Callable[..., WebRTCHarness],
+) -> None:
+    """Frontend ICE must use the signaling event and media mapping for each model."""
+    non_pro_client = FakeClient()
+    non_pro = harness_factory(clients=[non_pro_client])
+    await non_pro.manager.async_handle_async_webrtc_offer(
+        VIDEO_ONLY_OFFER, "non-pro", lambda message: None
+    )
+    await non_pro.manager.async_on_webrtc_candidate(
+        "non-pro", _candidate(mid=None, index=None, user_fragment=None)
+    )
+
+    pro_client = FakeClient()
+    pro = harness_factory(clients=[pro_client], pro=True)
+    await pro.manager.async_handle_async_webrtc_offer(
+        COMBINED_OFFER, "pro", lambda message: None
+    )
+    await pro.manager.async_on_webrtc_candidate(
+        "pro", _candidate(mid="audio-main", index=0)
+    )
+    await pro.manager.async_on_webrtc_candidate(
+        "pro", _candidate(mid="unknown", index=99)
+    )
+
+    non_pro_message = non_pro_client.websocket.sent[-1]
+    assert non_pro_message["event"] == "video-candidate"
+    assert _decode_sent_data(non_pro_message) == {
+        "candidate": "candidate:1 1 UDP 1 192.0.2.10 5000 typ host",
+        "sdpMLineIndex": 0,
+    }
+    assert [message["event"] for message in pro_client.websocket.sent[-3:]] == [
+        "audio-candidate",
+        "video-candidate",
+        "audio-candidate",
+    ]
+    for message in pro_client.websocket.sent[-3:]:
+        assert _decode_sent_data(message)["sdpMid"] == "0"
+        assert _decode_sent_data(message)["sdpMLineIndex"] == 0
+
+
+async def test_candidate_send_failure_is_home_assistant_error(
+    harness_factory: Callable[..., WebRTCHarness],
+) -> None:
+    """A live signaling write failure must use the integration's public error type."""
+    client = FakeClient()
+    harness = harness_factory(clients=[client])
+    await harness.manager.async_handle_async_webrtc_offer(
+        VIDEO_ONLY_OFFER, "session", lambda message: None
+    )
+    client.websocket.send_failures["video-candidate"] = RuntimeError("socket lost")
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="Unable to forward WebRTC candidate to NanoKVM: socket lost",
+    ):
+        await harness.manager.async_on_webrtc_candidate("session", _candidate())
+
+
+@pytest.mark.parametrize(
+    ("clients", "hass_ready", "message"),
+    [
+        ([None], True, "Missing NanoKVM WebRTC client"),
+        ([FakeClient()], False, "Home Assistant is not ready for WebRTC"),
+    ],
+)
+async def test_offer_requires_client_and_home_assistant(
+    harness_factory: Callable[..., WebRTCHarness],
+    clients: list[FakeClient | None],
+    hass_ready: bool,
+    message: str,
+) -> None:
+    """Missing runtime providers must fail before opening transport resources."""
+    harness = harness_factory(clients=clients, hass_ready=hass_ready)
+
+    with pytest.raises(HomeAssistantError, match=message):
+        await harness.manager.async_handle_async_webrtc_offer(
+            VIDEO_ONLY_OFFER, "session", lambda value: None
+        )
+
+    if clients[0] is not None:
+        assert clients[0].enter_calls == 0
+
+
+async def test_pro_offer_without_supported_media_is_rejected_before_client_entry(
+    harness_factory: Callable[..., WebRTCHarness],
+) -> None:
+    """A Pro peer request with no audio/video section must not open a client."""
+    client = FakeClient()
+    harness = harness_factory(clients=[client], pro=True)
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="offer does not contain audio or video media",
+    ):
+        await harness.manager.async_handle_async_webrtc_offer(
+            "v=0\r\nm=application 9 UDP/DTLS/SCTP 5000\r\n",
+            "session",
+            lambda value: None,
+        )
+
+    assert client.enter_calls == 0
+
+
+@pytest.mark.parametrize(
+    ("configure", "expected"),
+    [
+        (
+            lambda harness, client: setattr(
+                harness, "authenticate_error", RuntimeError("bad credentials")
+            ),
+            "bad credentials",
+        ),
+        (
+            lambda harness, client: setattr(client, "token", None),
+            "NanoKVM client authentication did not produce a token",
+        ),
+        (
+            lambda harness, client: setattr(client, "_session", None),
+            "NanoKVM client transport is not initialized",
+        ),
+        (
+            lambda harness, client: setattr(client, "_ssl_config", None),
+            "NanoKVM client transport is not initialized",
+        ),
+        (
+            lambda harness, client: setattr(
+                client.transport, "error", TimeoutError("connect timed out")
+            ),
+            "connect timed out",
+        ),
+    ],
+)
+async def test_offer_setup_failures_release_unregistered_client(
+    harness_factory: Callable[..., WebRTCHarness],
+    configure: Callable[[WebRTCHarness, FakeClient], None],
+    expected: str,
+) -> None:
+    """Failures before session startup must remove queues and exit the client."""
+    client = FakeClient()
+    harness = harness_factory(clients=[client])
+    configure(harness, client)
+
+    with pytest.raises(
+        HomeAssistantError,
+        match=f"Unable to establish NanoKVM WebRTC signaling: {expected}",
+    ):
+        await harness.manager.async_handle_async_webrtc_offer(
+            VIDEO_ONLY_OFFER, "session", lambda value: None
+        )
+
+    assert client.exit_calls == 1
+    assert client.websocket.close_calls == 0
+    assert "session" not in harness.manager._pending_candidates
+
+
+async def test_offer_write_failure_closes_registered_session(
+    harness_factory: Callable[..., WebRTCHarness],
+) -> None:
+    """A failed initial offer write must close WebSocket, task, and client."""
+    client = FakeClient()
+    client.websocket.send_failures["video-offer"] = RuntimeError("write failed")
+    harness = harness_factory(clients=[client])
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="Unable to establish NanoKVM WebRTC signaling: write failed",
+    ):
+        await harness.manager.async_handle_async_webrtc_offer(
+            VIDEO_ONLY_OFFER, "session", lambda value: None
+        )
+
+    assert client.websocket.closed
+    assert client.exit_calls == 1
+    assert harness.hass.tasks[0].cancelled()
+
+
+async def test_reader_timeout_reports_error_and_releases_session(
+    harness_factory: Callable[..., WebRTCHarness],
+) -> None:
+    """An aiohttp receive timeout must be visible to HA and clean up the session."""
+    client = FakeClient()
+    harness = harness_factory(clients=[client])
+    messages: list[object] = []
+    await harness.manager.async_handle_async_webrtc_offer(
+        VIDEO_ONLY_OFFER, "session", messages.append
+    )
+
+    client.websocket.feed_error(TimeoutError("signal timed out"))
+    await harness.hass.tasks[0]
+
+    assert messages == [
+        WebRTCError(code="webrtc_signal_failed", message="signal timed out")
+    ]
+    assert client.websocket.closed
+    assert client.exit_calls == 1
+
+
+async def test_pro_heartbeat_is_sent_until_shutdown_cancels_tasks(
+    harness_factory: Callable[..., WebRTCHarness],
+) -> None:
+    """Pro sessions must heartbeat and shutdown must cancel both owned tasks."""
+    client = FakeClient()
+    harness = harness_factory(
+        clients=[client], pro=True, signaling_heartbeat_seconds=0.001
+    )
+    await harness.manager.async_handle_async_webrtc_offer(
+        VIDEO_ONLY_OFFER, "session", lambda value: None
+    )
+
+    async with asyncio.timeout(1):
+        while not any(
+            message["event"] == "heartbeat" for message in client.websocket.sent
+        ):
+            await asyncio.sleep(0)
+    owned_tasks = tuple(harness.hass.tasks)
+    await harness.manager.async_shutdown()
+
+    assert [message["event"] for message in client.websocket.sent].count(
+        "heartbeat"
+    ) >= 1
+    assert all(task.cancelled() for task in owned_tasks)
+    assert client.exit_calls == 1
+
+
+async def test_heartbeat_failure_closes_session(
+    harness_factory: Callable[..., WebRTCHarness],
+) -> None:
+    """A failed Pro heartbeat must terminate and release the signaling session."""
+    client = FakeClient()
+    client.websocket.send_failures["heartbeat"] = RuntimeError("heartbeat failed")
+    harness = harness_factory(
+        clients=[client], pro=True, signaling_heartbeat_seconds=0.001
+    )
+    await harness.manager.async_handle_async_webrtc_offer(
+        VIDEO_ONLY_OFFER, "session", lambda value: None
+    )
+
+    async with asyncio.timeout(1):
+        while client.exit_calls == 0:
+            await asyncio.sleep(0)
+
+    assert client.websocket.closed
+    assert client.exit_calls == 1
+
+
+async def test_close_callback_schedules_cleanup_and_noops_without_hass(
+    harness_factory: Callable[..., WebRTCHarness],
+) -> None:
+    """Frontend unsubscribe must schedule cleanup only while HA is available."""
+    client = FakeClient()
+    harness = harness_factory(clients=[client])
+    await harness.manager.async_handle_async_webrtc_offer(
+        VIDEO_ONLY_OFFER, "session", lambda value: None
+    )
+
+    harness.manager.close_webrtc_session("session")
+    await harness.hass.tasks[-1]
+    assert client.exit_calls == 1
+
+    unavailable = harness_factory(hass_ready=False)
+    unavailable.manager.close_webrtc_session("missing")
+    assert unavailable.hass.tasks == []
+
+
+async def test_shutdown_closes_all_non_pro_sessions_and_tolerates_close_errors(
+    harness_factory: Callable[..., WebRTCHarness],
+) -> None:
+    """Manager shutdown must attempt every session even when resource closes fail."""
+    first = FakeClient()
+    first.websocket.close_error = RuntimeError("close failed")
+    first.exit_error = RuntimeError("exit failed")
+    second = FakeClient()
+    harness = harness_factory(clients=[first, second])
+    await harness.manager.async_handle_async_webrtc_offer(
+        VIDEO_ONLY_OFFER, "first", lambda value: None
+    )
+    await harness.manager.async_handle_async_webrtc_offer(
+        VIDEO_ONLY_OFFER, "second", lambda value: None
+    )
+    second.websocket.closed = True
+
+    await harness.manager.async_shutdown()
+
+    assert first.websocket.close_calls == 1
+    assert second.websocket.close_calls == 0
+    assert first.exit_calls == second.exit_calls == 1
+
+
+async def test_heartbeat_stops_when_websocket_is_already_closed(
+    harness_factory: Callable[..., WebRTCHarness],
+) -> None:
+    """A Pro heartbeat worker must retire after observing a closed transport."""
+    client = FakeClient()
+    harness = harness_factory(
+        clients=[client], pro=True, signaling_heartbeat_seconds=0.001
+    )
+    await harness.manager.async_handle_async_webrtc_offer(
+        VIDEO_ONLY_OFFER, "session", lambda value: None
+    )
+
+    client.websocket.closed = True
+    heartbeat_task = harness.hass.tasks[1]
+    async with asyncio.timeout(1):
+        await heartbeat_task
+
+    assert heartbeat_task.done()
+    assert [message["event"] for message in client.websocket.sent] == ["video-offer"]
+
+
+async def test_new_pro_session_closes_other_active_session_first(
+    harness_factory: Callable[..., WebRTCHarness],
+) -> None:
+    """NanoKVM Pro's single-stream constraint must retire another session."""
+    first = FakeClient()
+    second = FakeClient()
+    harness = harness_factory(clients=[first, second], pro=True)
+    await harness.manager.async_handle_async_webrtc_offer(
+        VIDEO_ONLY_OFFER, "first", lambda value: None
+    )
+
+    await harness.manager.async_handle_async_webrtc_offer(
+        VIDEO_ONLY_OFFER, "second", lambda value: None
+    )
+
+    assert first.websocket.closed
+    assert first.exit_calls == 1
+    assert not second.websocket.closed
+    assert second.exit_calls == 0
+
+
+async def test_legacy_aiohttp_timeout_uses_receive_timeout(
+    harness_factory: Callable[..., WebRTCHarness], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Older aiohttp releases must receive their supported timeout keyword."""
+    client = FakeClient()
+    harness = harness_factory(clients=[client])
+    monkeypatch.delattr(webrtc_module.aiohttp, "ClientWSTimeout")
+
+    await harness.manager.async_handle_async_webrtc_offer(
+        VIDEO_ONLY_OFFER, "session", lambda value: None
+    )
+
+    kwargs = client.transport.calls[0][1]
+    assert kwargs["receive_timeout"] == 15.0
+    assert "timeout" not in kwargs
+
+
+async def test_invalid_device_candidate_is_ignored(
+    harness_factory: Callable[..., WebRTCHarness],
+) -> None:
+    """Malformed ICE from a device must not escape the signaling reader."""
+    client = FakeClient()
+    harness = harness_factory(clients=[client])
+    messages: list[object] = []
+    await harness.manager.async_handle_async_webrtc_offer(
+        VIDEO_ONLY_OFFER, "session", messages.append
+    )
+
+    client.websocket.feed_signal("video-candidate", json.dumps({"sdpMid": "0"}))
+    await _finish_reader(client, harness.hass)
+
+    assert messages == []

--- a/tests/unit/test_ssh_metrics.py
+++ b/tests/unit/test_ssh_metrics.py
@@ -1,0 +1,529 @@
+"""Tests for NanoKVM SSH metric collection and parsing."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import inspect
+from collections.abc import Awaitable, Callable
+from unittest.mock import MagicMock
+
+import pytest
+
+import custom_components.nanokvm.ssh_metrics as ssh_metrics_module
+from custom_components.nanokvm.ssh_metrics import (
+    SSHMetricsCollector,
+    SSHMetricsSnapshot,
+)
+
+
+class _FakeSSHClient:
+    """Controllable fake for the external NanoKVM SSH boundary."""
+
+    def __init__(self, ssh_client: object | None) -> None:
+        self.ssh_client = ssh_client
+        self.authenticate_calls: list[str] = []
+        self.authenticate_error: BaseException | None = None
+        self.disconnect_calls = 0
+        self.run_command_calls: list[str] = []
+        self.run_command_result = ""
+        self.run_command_error: BaseException | None = None
+        self.run_command_callback: Callable[[str], str | Awaitable[str]] | None = None
+
+    async def authenticate(self, password: str) -> None:
+        """Record authentication and raise any configured boundary error."""
+        self.authenticate_calls.append(password)
+        if self.authenticate_error is not None:
+            raise self.authenticate_error
+
+    async def disconnect(self) -> None:
+        """Record an SSH disconnect request."""
+        self.disconnect_calls += 1
+
+    async def run_command(self, command: str) -> str:
+        """Return configured output or propagate a configured boundary failure."""
+        self.run_command_calls.append(command)
+        if self.run_command_error is not None:
+            raise self.run_command_error
+        if self.run_command_callback is not None:
+            result = self.run_command_callback(command)
+            if inspect.isawaitable(result):
+                return await result
+            return result
+        return self.run_command_result
+
+
+def _collector(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    ssh_client: object | None = None,
+) -> tuple[SSHMetricsCollector, _FakeSSHClient, MagicMock]:
+    """Return a collector whose external SSH client boundary is mocked."""
+    client = _FakeSSHClient(ssh_client)
+    client_factory = MagicMock(return_value=client)
+    monkeypatch.setattr(ssh_metrics_module, "NanoKVMSSH", client_factory)
+
+    collector = SSHMetricsCollector(
+        host="nanokvm.local",
+        password="secret",
+        username="operator",
+    )
+    return collector, client, client_factory
+
+
+class _Transport:
+    """Minimal transport boundary consumed by the collector."""
+
+    def __init__(self, *, active: bool) -> None:
+        self._active = active
+
+    def is_active(self) -> bool:
+        """Return the configured transport state."""
+        return self._active
+
+
+class _Connection:
+    """Minimal SSH connection boundary consumed by the collector."""
+
+    def __init__(self, transport: _Transport | None) -> None:
+        self._transport = transport
+        self.get_transport_calls = 0
+
+    def get_transport(self) -> _Transport | None:
+        """Return the configured transport and record the observation."""
+        self.get_transport_calls += 1
+        return self._transport
+
+
+def _active_connection() -> _Connection:
+    """Return an SSH connection with an active transport."""
+    return _Connection(_Transport(active=True))
+
+
+def _command_outputs(*, watchdog: str = "1") -> dict[str, str]:
+    """Return representative NanoKVM command output."""
+    return {
+        "cat /proc/stat": "cpu  1 2 3\nbtime 1700000000\nprocesses 9",
+        "cat /sys/class/thermal/thermal_zone0/temp": "42000\n",
+        "cat /proc/meminfo": ("MemTotal:       1048576 kB\nMemAvailable:    262144 kB"),
+        "df -k /": (
+            "Filesystem 1K-blocks Used Available Use% Mounted on\n"
+            "/dev/root 2097152 524288 1572864 25% /"
+        ),
+        "test -f /etc/kvm/watchdog && echo 1 || echo 0": watchdog,
+    }
+
+
+def _serve_outputs(client: _FakeSSHClient, *, watchdog: str = "1") -> None:
+    """Configure the mocked SSH boundary to serve command-specific output."""
+    outputs = _command_outputs(watchdog=watchdog)
+
+    async def run_command(command: str) -> str:
+        return outputs[command]
+
+    client.run_command_callback = run_command
+
+
+def test_snapshot_exposes_all_collected_values() -> None:
+    """A snapshot preserves each independently collected metric."""
+    uptime = datetime.datetime(2023, 11, 14, 22, 13, 20, tzinfo=datetime.UTC)
+
+    snapshot = SSHMetricsSnapshot(
+        uptime=uptime,
+        cpu_temperature=42.0,
+        memory_total=1024.0,
+        memory_used_percent=75.0,
+        storage_total=2048.0,
+        storage_used_percent=25.0,
+        watchdog_enabled=True,
+    )
+
+    assert snapshot.uptime is uptime
+    assert snapshot.cpu_temperature == 42.0
+    assert snapshot.memory_total == 1024.0
+    assert snapshot.memory_used_percent == 75.0
+    assert snapshot.storage_total == 2048.0
+    assert snapshot.storage_used_percent == 25.0
+    assert snapshot.watchdog_enabled is True
+
+
+def test_constructor_configures_the_library_ssh_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Collector construction forwards only connection identity to the client."""
+    collector, client, client_factory = _collector(monkeypatch)
+
+    client_factory.assert_called_once_with(host="nanokvm.local", username="operator")
+    assert collector._client is client
+
+
+@pytest.mark.parametrize("connected", [False, True])
+async def test_disconnect_only_closes_an_existing_connection(
+    monkeypatch: pytest.MonkeyPatch,
+    connected: bool,
+) -> None:
+    """Disconnect is safe before connection and closes an active client once."""
+    connection = _active_connection() if connected else None
+    collector, client, _ = _collector(monkeypatch, ssh_client=connection)
+
+    await collector.disconnect()
+
+    if connected:
+        assert client.disconnect_calls == 1
+    else:
+        assert client.disconnect_calls == 0
+
+
+@pytest.mark.parametrize(
+    "connection_state",
+    ["missing-client", "missing-transport", "inactive-transport"],
+)
+async def test_ensure_connected_authenticates_unusable_connections(
+    monkeypatch: pytest.MonkeyPatch,
+    connection_state: str,
+) -> None:
+    """Missing or inactive SSH transports trigger password authentication."""
+    connection: _Connection | None = None
+    if connection_state != "missing-client":
+        transport = None
+        if connection_state == "inactive-transport":
+            transport = _Transport(active=False)
+        connection = _Connection(transport)
+    collector, client, _ = _collector(monkeypatch, ssh_client=connection)
+
+    await collector._async_ensure_connected()
+
+    assert client.authenticate_calls == ["secret"]
+
+
+async def test_ensure_connected_reuses_an_active_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An active SSH transport is reusable without authentication."""
+    connection = _active_connection()
+    collector, client, _ = _collector(monkeypatch, ssh_client=connection)
+
+    await collector._async_ensure_connected()
+
+    assert connection.get_transport_calls == 1
+    assert client.authenticate_calls == []
+
+
+async def test_collect_returns_parsed_metrics_without_optional_watchdog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A default collection produces one complete snapshot from device output."""
+    collector, client, _ = _collector(
+        monkeypatch,
+        ssh_client=_active_connection(),
+    )
+    _serve_outputs(client)
+
+    snapshot = await collector.collect()
+
+    assert snapshot == SSHMetricsSnapshot(
+        uptime=datetime.datetime(2023, 11, 14, 22, 13, 20, tzinfo=datetime.UTC),
+        cpu_temperature=42.0,
+        memory_total=1024.0,
+        memory_used_percent=75.0,
+        storage_total=2048.0,
+        storage_used_percent=25.0,
+        watchdog_enabled=None,
+    )
+    assert client.run_command_calls == [
+        "cat /proc/stat",
+        "cat /sys/class/thermal/thermal_zone0/temp",
+        "cat /proc/meminfo",
+        "df -k /",
+    ]
+    assert client.authenticate_calls == []
+
+
+async def test_collect_can_include_watchdog_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Callers can request the optional watchdog value in the same snapshot."""
+    collector, client, _ = _collector(
+        monkeypatch,
+        ssh_client=_active_connection(),
+    )
+    _serve_outputs(client)
+
+    snapshot = await collector.collect(include_watchdog=True)
+
+    assert snapshot.watchdog_enabled is True
+    assert client.run_command_calls[-1] == (
+        "test -f /etc/kvm/watchdog && echo 1 || echo 0"
+    )
+
+
+async def test_repeated_collection_reuses_the_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated refreshes remain idempotent while the transport stays active."""
+    collector, client, _ = _collector(
+        monkeypatch,
+        ssh_client=_active_connection(),
+    )
+    _serve_outputs(client)
+
+    first = await collector.collect()
+    second = await collector.collect()
+
+    assert first == second
+    assert len(client.run_command_calls) == 8
+    assert client.authenticate_calls == []
+
+
+async def test_concurrent_collection_reuses_an_active_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent readers can share an already active SSH connection."""
+    collector, client, _ = _collector(
+        monkeypatch,
+        ssh_client=_active_connection(),
+    )
+    outputs = _command_outputs()
+    first_commands_started = 0
+    both_collectors_started = asyncio.Event()
+
+    async def run_command(command: str) -> str:
+        nonlocal first_commands_started
+        if command == "cat /proc/stat":
+            first_commands_started += 1
+            if first_commands_started == 2:
+                both_collectors_started.set()
+            await both_collectors_started.wait()
+        return outputs[command]
+
+    client.run_command_callback = run_command
+
+    snapshots = await asyncio.gather(collector.collect(), collector.collect())
+
+    assert first_commands_started == 2
+    assert snapshots[0] == snapshots[1]
+    assert len(client.run_command_calls) == 8
+    assert client.authenticate_calls == []
+
+
+async def test_collect_propagates_authentication_errors_without_running_commands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Connection failures reach the coordinator without partial collection."""
+    collector, client, _ = _collector(monkeypatch)
+    client.authenticate_error = RuntimeError("authentication failed")
+
+    with pytest.raises(RuntimeError, match="authentication failed"):
+        await collector.collect()
+
+    assert client.run_command_calls == []
+
+
+async def test_collect_stops_after_an_ssh_command_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Command failures propagate and later metrics are not requested."""
+    collector, client, _ = _collector(
+        monkeypatch,
+        ssh_client=_active_connection(),
+    )
+    client.run_command_error = RuntimeError("SSH command failed")
+
+    with pytest.raises(RuntimeError, match="SSH command failed"):
+        await collector.collect()
+
+    assert client.run_command_calls == ["cat /proc/stat"]
+
+
+async def test_collect_propagates_cancellation_without_starting_later_commands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancelling an in-flight command promptly cancels the collection."""
+    collector, client, _ = _collector(
+        monkeypatch,
+        ssh_client=_active_connection(),
+    )
+    command_started = asyncio.Event()
+
+    async def stalled_command(command: str) -> str:
+        assert command == "cat /proc/stat"
+        command_started.set()
+        await asyncio.Event().wait()
+        return ""
+
+    client.run_command_callback = stalled_command
+    task = asyncio.create_task(collector.collect())
+    await command_started.wait()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert client.run_command_calls == ["cat /proc/stat"]
+
+
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [("1", True), (" 1\n", True), ("0", False), ("", False)],
+)
+async def test_fetch_watchdog_enabled_parses_device_output(
+    monkeypatch: pytest.MonkeyPatch,
+    output: str,
+    expected: bool,
+) -> None:
+    """Only the device's exact enabled marker reports an active watchdog."""
+    collector, client, _ = _collector(
+        monkeypatch,
+        ssh_client=_active_connection(),
+    )
+    client.run_command_result = output
+
+    assert await collector.fetch_watchdog_enabled() is expected
+    assert client.run_command_calls == ["test -f /etc/kvm/watchdog && echo 1 || echo 0"]
+
+
+@pytest.mark.parametrize(
+    ("enabled", "command"),
+    [
+        (True, "touch /etc/kvm/watchdog"),
+        (False, "rm -f /etc/kvm/watchdog"),
+    ],
+)
+async def test_set_watchdog_enabled_runs_the_safe_device_command(
+    monkeypatch: pytest.MonkeyPatch,
+    enabled: bool,
+    command: str,
+) -> None:
+    """Both watchdog transitions use their corresponding idempotent command."""
+    collector, client, _ = _collector(
+        monkeypatch,
+        ssh_client=_active_connection(),
+    )
+
+    await collector.set_watchdog_enabled(enabled)
+
+    assert client.run_command_calls == [command]
+
+
+async def test_fetch_uptime_returns_none_without_a_valid_boot_time_record(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unrelated and malformed proc-stat records do not invent an uptime."""
+    collector, client, _ = _collector(monkeypatch)
+    client.run_command_result = "cpu\nintr 1\nbtime 1 extra\nctxt 4"
+
+    assert await collector._fetch_uptime() is None
+
+
+async def test_fetch_uptime_propagates_an_invalid_boot_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid numeric device output remains an explicit collection failure."""
+    collector, client, _ = _collector(monkeypatch)
+    client.run_command_result = "btime invalid"
+
+    with pytest.raises(ValueError, match="invalid literal"):
+        await collector._fetch_uptime()
+
+
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        ("malformed\nMemAvailable: 512", {"total": None, "used_percent": None}),
+        ("MemTotal: 0\nMemAvailable: 512", {"total": 0.0, "used_percent": None}),
+        ("MemTotal: 1024", {"total": 1.0, "used_percent": None}),
+        (
+            "MemTotal: 1024\nMemAvailable: 256",
+            {"total": 1.0, "used_percent": 75.0},
+        ),
+    ],
+)
+async def test_fetch_memory_handles_partial_and_complete_meminfo(
+    monkeypatch: pytest.MonkeyPatch,
+    output: str,
+    expected: dict[str, float | None],
+) -> None:
+    """Memory parsing returns only values supported by complete device records."""
+    collector, client, _ = _collector(monkeypatch)
+    client.run_command_result = output
+
+    assert await collector._fetch_memory() == expected
+
+
+async def test_fetch_memory_propagates_invalid_numeric_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-numeric meminfo values remain visible to coordinator recovery logic."""
+    collector, client, _ = _collector(monkeypatch)
+    client.run_command_result = "MemTotal: invalid"
+
+    with pytest.raises(ValueError, match="invalid literal"):
+        await collector._fetch_memory()
+
+
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [("42000\n", 42.0), ("42", 42.0), ("1000", 1000.0)],
+)
+async def test_fetch_cpu_temperature_normalizes_millidegrees(
+    monkeypatch: pytest.MonkeyPatch,
+    output: str,
+    expected: float,
+) -> None:
+    """Thermal values above the threshold convert from millidegrees Celsius."""
+    collector, client, _ = _collector(monkeypatch)
+    client.run_command_result = output
+
+    assert await collector._fetch_cpu_temperature() == expected
+
+
+async def test_fetch_cpu_temperature_propagates_invalid_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing numeric temperature remains an explicit collection error."""
+    collector, client, _ = _collector(monkeypatch)
+    client.run_command_result = ""
+
+    with pytest.raises(ValueError, match="could not convert"):
+        await collector._fetch_cpu_temperature()
+
+
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        ("Filesystem 1K-blocks Used", {"total": None, "used_percent": None}),
+        (
+            "Filesystem 1K-blocks Used Available Use% Mounted on\n/dev/root 100",
+            {"total": None, "used_percent": None},
+        ),
+        (
+            "Filesystem 1K-blocks Used Available Use% Mounted on\n"
+            "/dev/root 1048576 524288 524288 50% /",
+            {"total": 1024.0, "used_percent": 50.0},
+        ),
+    ],
+)
+async def test_fetch_storage_handles_partial_and_complete_df_output(
+    monkeypatch: pytest.MonkeyPatch,
+    output: str,
+    expected: dict[str, float | None],
+) -> None:
+    """Storage parsing returns values only for a complete data row."""
+    collector, client, _ = _collector(monkeypatch)
+    client.run_command_result = output
+
+    assert await collector._fetch_storage() == expected
+
+
+async def test_fetch_storage_propagates_invalid_numeric_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid df numbers remain visible to coordinator recovery logic."""
+    collector, client, _ = _collector(monkeypatch)
+    client.run_command_result = (
+        "Filesystem 1K-blocks Used Available Use% Mounted on\n"
+        "/dev/root invalid 1 1 1% /"
+    )
+
+    with pytest.raises(ValueError, match="invalid literal"):
+        await collector._fetch_storage()


### PR DESCRIPTION
## Summary

- add focused camera platform tests for setup, stream-client authentication, snapshots, WebRTC delegation, and cleanup
- cover non-Pro and Pro WebRTC signaling, candidate routing, concurrency, timeouts, failures, heartbeats, and shutdown
- cover SSH connection reuse, metric parsing, watchdog operations, errors, cancellation, and concurrent collection
- include the Home Assistant camera runtime dependency in the test environment

## Impact

Raises total integration coverage from 76% to 99% while keeping the PR tests-only. Camera and SSH metrics reach 100% line and branch coverage; the WebRTC manager reaches 98.6% line coverage and 95.8% branch coverage. The remaining WebRTC paths are defensive internal invariants.