### PR TITLE
test: add coverage regression gate

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,5 +3,7 @@ branch = True
 source = custom_components.nanokvm
 
 [report]
+fail_under = 98
+precision = 2
 show_missing = True
 skip_empty = True

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,41 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    name: Python tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: requirements_test.txt
+
+      - name: Install test dependencies
+        run: python -m pip install -r requirements_test.txt
+
+      - name: Run Ruff
+        run: python -m ruff check custom_components/nanokvm tests
+
+      - name: Run tests with branch coverage
+        run: |
+          python -m coverage erase
+          python -m coverage run -m pytest -q
+          python -m coverage report

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,24 +143,29 @@ Each platform follows a similar pattern:
 
 Run these checks locally before pushing:
 
-1. Python checks:
+1. Automated tests with branch coverage:
+   - `python -m coverage erase`
+   - `python -m coverage run -m pytest -q`
+   - `python -m coverage report`
+2. Python checks:
    - `python -m ruff check custom_components/nanokvm`
    - `python -m py_compile custom_components/nanokvm/*.py`
-2. Validate JSON metadata, strings, and translations:
+3. Validate JSON metadata, strings, and translations:
    - `python -m json.tool hacs.json`
    - `python -m json.tool custom_components/nanokvm/manifest.json`
    - `python -m json.tool custom_components/nanokvm/strings.json`
    - `python -m json.tool custom_components/nanokvm/translations/en.json`
    - `python -m json.tool custom_components/nanokvm/translations/fr.json`
    - `python -m json.tool custom_components/nanokvm/translations/pt-BR.json`
-3. Verify the integration against a Home Assistant test instance and inspect logs.
+4. Verify the integration against a Home Assistant test instance and inspect logs.
 
 ## Required GitHub Workflows
 
+- Tests: `.github/workflows/tests.yaml`
 - HACS: `.github/workflows/hacs.yaml`
 - Hassfest: `.github/workflows/hassfest.yaml`
 
-Both should be green on the PR branch before merge/release.
+All three should be green on the PR branch before merge/release.
 
 [ha-url]: https://www.home-assistant.io/
 [nanokvm-url]: https://github.com/sipeed/NanoKVM

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,8 @@ python -m coverage run -m pytest
 python -m coverage report
 ```
 
+The coverage report enforces the repository's 98% combined line/branch floor.
+
 Then run the integration validation checks:
 
 1. `python -m ruff check custom_components/nanokvm`
@@ -55,6 +57,7 @@ When behavior changes, also test the integration on a Home Assistant instance.
 
 CI must pass on the PR branch:
 
+- `.github/workflows/tests.yaml`
 - `.github/workflows/hacs.yaml`
 - `.github/workflows/hassfest.yaml`
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![HACS][badge-hacs]][link-hacs]
 [![GitHub Release][badge-release]][link-release]
 [![GitHub Commit Activity][badge-commit-activity]][link-commits]
+[![Tests][badge-tests]][link-tests]
 [![HACS Validation][badge-hacs-validation]][link-hacs-validation]
 [![Hassfest][badge-hassfest]][link-hassfest]
 
@@ -202,10 +203,12 @@ automation:
 [badge-hacs]: https://img.shields.io/badge/HACS-Default-41BDF5.svg
 [badge-release]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2FWouter0100%2Fhomeassistant-nanokvm%2Freleases%2Flatest&query=%24.tag_name&label=release
 [badge-commit-activity]: https://img.shields.io/github/commit-activity/m/Wouter0100/homeassistant-nanokvm
+[badge-tests]: https://github.com/Wouter0100/homeassistant-nanokvm/actions/workflows/tests.yaml/badge.svg
 [badge-hacs-validation]: https://github.com/Wouter0100/homeassistant-nanokvm/actions/workflows/hacs.yaml/badge.svg
 [badge-hassfest]: https://github.com/Wouter0100/homeassistant-nanokvm/actions/workflows/hassfest.yaml/badge.svg
 [link-hacs]: https://github.com/custom-components/hacs
 [link-release]: https://github.com/Wouter0100/homeassistant-nanokvm/releases/latest
 [link-commits]: https://github.com/Wouter0100/homeassistant-nanokvm/commits/main
+[link-tests]: https://github.com/Wouter0100/homeassistant-nanokvm/actions/workflows/tests.yaml
 [link-hacs-validation]: https://github.com/Wouter0100/homeassistant-nanokvm/actions/workflows/hacs.yaml
 [link-hassfest]: https://github.com/Wouter0100/homeassistant-nanokvm/actions/workflows/hassfest.yaml


### PR DESCRIPTION
## Summary

- add a Python 3.14 Tests workflow for pull requests and pushes to dev or main
- enforce a 98% combined line and branch coverage floor through the existing coverage configuration
- run Ruff and the complete pytest suite in CI
- document the new required workflow and add its README badge

## Impact

The measured baseline is 98.98% combined coverage, so the 98% floor prevents meaningful regressions without requiring artificial 100% coverage. Existing defensive gaps remain visible because no exclusion patterns were added.